### PR TITLE
five.pt / Chameleon compatibility

### DIFF
--- a/Products/CMFPlomino/skins/cmfplomino_templates/DOCLINKFieldEdit.pt
+++ b/Products/CMFPlomino/skins/cmfplomino_templates/DOCLINKFieldEdit.pt
@@ -3,7 +3,7 @@
 				name python:options['fieldname'];
 				current python:options['fieldvalue'];
 				lcurrent python:test(hasattr(current,'split'),[current],current);
-				lcurrent_ids python:[path.split('/')[-1] for path in lcurrent];
+				lcurrent_ids python:[p.split('/')[-1] for p in lcurrent];
 				">
 	<tal:widget tal:condition="python:test(widget=='SELECT')">
 		<select tal:attributes="name name"><tal:loop tal:repeat="v selection">


### PR DESCRIPTION
Chameleon does not like the variable name "path" in list expansions. Replace it with "p".
