### PR TITLE
changed getHidewhenAsJSON introducing a prior form

### DIFF
--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -530,11 +530,11 @@ class PlominoForm(ATFolder):
         return False
 
     security.declareProtected(READ_PERMISSION, 'getHidewhenAsJSON')
-    def getHidewhenAsJSON(self, REQUEST, form=None):
+    def getHidewhenAsJSON(self, REQUEST, parent_form=None):
         """Return a JSON object to dynamically show or hide hidewhens (works only with isDynamicHidewhen)
         """
         result = {}
-        target = TemporaryDocument(self.getParentDatabase(), form or self, REQUEST)
+        target = TemporaryDocument(self.getParentDatabase(), parent_form or self, REQUEST)
         for hidewhen in self.getHidewhenFormulas():
             if getattr(hidewhen, 'isDynamicHidewhen', False):
                 try:
@@ -546,7 +546,7 @@ class PlominoForm(ATFolder):
                 result[hidewhen.id] = isHidden 
         for subformname in self.getSubforms():
             form = self.getParentDatabase().getForm(subformname)
-            form_hidewhens = json.loads(form.getHidewhenAsJSON(REQUEST, form=self))
+            form_hidewhens = json.loads(form.getHidewhenAsJSON(REQUEST, parent_form=parent_form or self))
             result.update(form_hidewhens)
 
         return json.dumps(result)


### PR DESCRIPTION
Hi,
I noticed that asking to the Form property to the context of an hide-when nested in a sub-form it returns not the name of the form of the document but the name of the sub-form that contains the hideWhen object. Applying this patch everything seams go as expected. 
