### PR TITLE
Don't raise an error if a field is included more than once.

### DIFF
--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -687,7 +687,7 @@ class PlominoForm(ATFolder):
                     report = ', '.join(
                             ['%s (occurs %s times)'%(f,c)
                                 for f,c in matches.items()])
-                    logger.debug('Ambiguous fieldname: %s, picked %s'%(
+                    logger.warning('Ambiguous fieldname: %s, picked %s'%(
                         report,
                         '/'.join(field.getPhysicalPath())))
         return field


### PR DESCRIPTION
Log what was found and what was picked.
