### PR TITLE
Start to make potentially expensive operations POST-only.

### DIFF
--- a/Products/CMFPlomino/PlominoDesignManager.py
+++ b/Products/CMFPlomino/PlominoDesignManager.py
@@ -25,6 +25,7 @@ import xmlrpclib
 
 # Zope
 from Acquisition import *
+from AccessControl.requestmethod import postonly
 from DateTime import DateTime
 from HttpUtils import authenticateAndLoadURL, authenticateAndPostToURL
 from Persistence import Persistent
@@ -102,14 +103,15 @@ def run_refreshdb(context):
 
 
 class PlominoDesignManager(Persistent):
-    """Plomino design import/export features
+    """ Plomino design import/export features
     """
     security = ClassSecurityInfo()
 
     # Methods
     security.declarePublic('manage_refreshDB')
+    @postonly
     def manage_refreshDB(self, REQUEST):
-        """launch refreshDB
+        """ Launch refreshDB
         """
         if ASYNC:
             self.refreshDB_async()
@@ -296,6 +298,7 @@ class PlominoDesignManager(Persistent):
         return msg
 
     security.declareProtected(DESIGN_PERMISSION, 'refreshDB')
+    @postonly
     def recomputeAllDocuments(self, REQUEST=None):
         """
         """
@@ -336,6 +339,7 @@ class PlominoDesignManager(Persistent):
             REQUEST.RESPONSE.redirect(self.absolute_url()+"/DatabaseDesign")
 
     security.declareProtected(DESIGN_PERMISSION, 'refreshPortalCatalog')
+    @postonly
     def refreshPortalCatalog(self, REQUEST=None):
         """
         """

--- a/Products/CMFPlomino/skins/cmfplomino_templates/DatabaseDesign.pt
+++ b/Products/CMFPlomino/skins/cmfplomino_templates/DatabaseDesign.pt
@@ -151,11 +151,14 @@
 </dd></dl>
 <hr/><h3 i18n:translate="">Refresh database</h3>
 <ul>
-  <li><a href="./manage_refreshDB" i18n:translate="">Refresh database</a>
+    <li><form name="Refresh" action="manage_refreshDB" method="POST">
+        <input type="submit" name="submit_refresh" class="context" value="Refresh database" i18n:attributes="value"/></form>
   <span i18n:translate="">(clean scripts, re-index documents, and check Plomino version migration)</span></li>     
-  <li><a href="./recomputeAllDocuments" i18n:translate="">Re-compute documents</a>
+  <li><form name="Recompute" action="recomputeAllDocuments" method="POST">
+        <input type="submit" name="submit_recompute" class="context" value="Re-compute documents" i18n:attributes="value"/></form>
   <span i18n:translate="">(save all documents with their current form: computed fields and computed on save fields will be re-computed and stored, and documents are re-indexed)</span></li>
-  <li><a href="./refreshPortalCatalog" i18n:translate="">Re-index documents in portal catalog</a>
+  <li><form name="RefreshCatalog" action="refreshPortalCatalog" method="POST">
+        <input type="submit" name="submit_refreshcatalog" class="context" value="Re-index documents in portal catalog" i18n:attributes="value"/></form>
   <span i18n:translate="">(if the database allows portal catalog indexing, documents are re-indexed, else they are removed from the catalog)</span>
   </li>
 </ul>


### PR DESCRIPTION
This will help prevent triggering a refresh accidentally, such as
when restoring a browser session after a crash.
