### PR TITLE
Enable using the database date format from PlominoUtils

### DIFF
--- a/Products/CMFPlomino/PlominoUtils.py
+++ b/Products/CMFPlomino/PlominoUtils.py
@@ -88,6 +88,8 @@ def StringToDate(str_d, format='%Y-%m-%d', db=None):
     With StringToDate, it's best to have a fixed default format, 
     as it is easier for formulas to control the input date string than the
     portal date format.
+
+    Pass `format=None` to allow StringToDate to guess.
     """
     try:
         if db:


### PR DESCRIPTION
In the case of StringToDate it's better to have a fixed default, as
you may risk breakage when the database date format changes, but you are
still getting date strings in the same format as before.
