### PR TITLE
Don't prevent calling from a debug prompt.

### DIFF
--- a/Products/CMFPlomino/PlominoAccessControl.py
+++ b/Products/CMFPlomino/PlominoAccessControl.py
@@ -114,8 +114,9 @@ class PlominoAccessControl(Persistent):
         self.ACL_initialized = 0
         self.UserRoles = {}
 
-    def _redirectIfResponse(REQUEST, target):
-        response = getattr(REQUEST, 'RESPONSE', None)
+    def _redirectIfResponse(self, target):
+        request = getattr(self, 'REQUEST', None)
+        response = getattr(request, 'RESPONSE', None)
         if response:
             response.redirect(target)
 


### PR DESCRIPTION
I think this commit is a step in the right direction, however it still requires something like this before calling the relevant methods:

```
from zope.component.hooks import setSite
setSite(plone)

from sys import stdin, stdout
from ZPublisher.HTTPRequest import HTTPRequest
from ZPublisher.HTTPResponse import HTTPResponse
from ZPublisher.BaseRequest import RequestContainer

def hacked_makerequest(stdout=None, environ={}):
    resp = HTTPResponse(stdout=stdout)
    environ.setdefault('SERVER_NAME', 'foo')
    environ.setdefault('SERVER_PORT', '80')
    environ.setdefault('REQUEST_METHOD',  'GET')
    req = HTTPRequest(stdin, environ, resp)
    req._steps = ['noobject']  # Fake a published object.
    req['ACTUAL_URL'] = req.get('URL') # Zope 2.7.4
    from zope.publisher.browser import setDefaultSkin
    setDefaultSkin(req)
    requestcontainer = RequestContainer(REQUEST = req)
    return requestcontainer

plone.REQUEST = hacked_makerequest()
```

And after calling them (e.g. `addPlominoRoleToUser`) it is necessary to `del plone.REQUEST` to avoid a traceback when trying to pickle `stdin`.
