### PR TITLE
Teach formulas about their id

### DIFF
--- a/Products/CMFPlomino/PlominoDesignManager.py
+++ b/Products/CMFPlomino/PlominoDesignManager.py
@@ -92,6 +92,7 @@ logger = logging.getLogger('Plomino')
 
 STR_FORMULA = """plominoContext = context
 plominoDocument = context
+script_id = '%(script_id)s'
 %(import_list)s
 
 %(formula)s
@@ -688,6 +689,7 @@ class PlominoDesignManager(Persistent):
                 not formula.startswith('return ')):
             formula = "return " + formula
         str_formula = STR_FORMULA % {
+                'script_id': script_id,
                 'import_list': import_list,
                 'formula': formula
                 }


### PR DESCRIPTION
This allows writing formulas that can adapt depending on what script
they're in.

For example, when using a configuration as in http://www.plomino.net/how-to/configuration-forms-and-documents
the fields could get their default values like this:

```
#Plomino import libConfig
ignore, ignore, rest = script_id.split('_', 2)
field_id, ignore = rest.rsplit('_', 1) 
return libConfig_getValuesAsDict(field_id).keys()
```
