### PR TITLE
Name the view form, same as for document forms.

### DIFF
--- a/Products/CMFPlomino/skins/cmfplomino_templates/OpenView.pt
+++ b/Products/CMFPlomino/skins/cmfplomino_templates/OpenView.pt
@@ -30,7 +30,7 @@
                             here.hasReadPermission(here)==True and
                             here.hasReadPermission(here.getParentDatabase())==True)">
 
-            <form name="plominoviewform">
+            <form tal:attributes="name python:myF.id" class="plominoviewform">
             <tal:block
                 tal:condition="python:test(hasReadPermission==True)">
                 <tal:block


### PR DESCRIPTION
Enable styling individual views. 
Pull request because existing CSS for `[@name=plominoviewform]` will break. 
