### PR TITLE
Jean pretty layout

### DIFF
--- a/Products/CMFPlomino/PlominoDesignManager.py
+++ b/Products/CMFPlomino/PlominoDesignManager.py
@@ -924,6 +924,7 @@ class PlominoDesignManager(Persistent):
                                     encoding="utf-8",
                                     pretty_print=True,
                                     method='html')
+                            s = s.split('<html><body>')[1].split('</body></html>')[0]
                         except ImportError:
                             # XXX: Blunt object replace:
                             s = s.decode('utf-8').replace("><", ">\n<")


### PR DESCRIPTION
This can lose some info if the HTML is weird, e.g.:

```
>>> ss = u'''<!-- P { margin-bottom: 0.08in; } --><p><b> </b></p><p align="CENTER"><b>TEXT</b><!-- comment --></p>'''
# First comment is lost
>>> [e for e in etree.parse(StringIO(ss), parser).iter()]
[<Element html at b6d9334c>, <Element body at b6d93374>, <Element p at b6d932fc>, <Element b at b6d9339c>, <Element p at b6d932ac>, <Element b at b6d933ec>, <!-- comment -->]
>>> ss = u'''<b><!-- P { margin-bottom: 0.08in; } --><p><b> </b></p><p align="CENTER"><b>TEXT</b><!-- comment --></p>'''
# First comment is kept
>>> [e for e in etree.parse(StringIO(ss), parser).iter()][<Element html at b6d936e4>, <Element body at b6d9370c>, <Element b at b6d932d4>, <!-- P { margin-bottom: 0.08in; } -->, <Element p at b6d93734>, <Element b at b6d9375c>, <Element p at b6d93784>, <Element b at b6d937ac>, <!-- comment -->]
```

For me the benefits outweigh this concern. 
