### PR TITLE
Allow plomino cache to be added to a view

### DIFF
--- a/Products/CMFPlomino/profiles/default/types/PlominoView.xml
+++ b/Products/CMFPlomino/profiles/default/types/PlominoView.xml
@@ -15,6 +15,7 @@
  <property name="allowed_content_types">
    <element value="PlominoAction"/>
    <element value="PlominoColumn"/>
+   <element value="PlominoCache"/>
  </property>
  <property name="allow_discussion">False</property>
  <property name="default_view">checkBeforeOpenView</property>


### PR DESCRIPTION
Hi Eric,

I wanted to make sure you are ok with this change. Use case is caching a view to be passed through an agent to download a csv dump of the data. Not sure if you would rather a view level cache should be created at the database level or within the view itself.

Cheers
Michael
