### PR TITLE
Encode page forms also

### DIFF
--- a/Products/CMFPlomino/skins/cmfplomino_templates/OpenBareForm.pt
+++ b/Products/CMFPlomino/skins/cmfplomino_templates/OpenBareForm.pt
@@ -207,7 +207,9 @@
             <h1 class="documentFirstHeading"
                 tal:content="here/Title">Title</h1>
             <form id="plomino_form"
-                tal:attributes="name here/id">
+                tal:attributes="name here/id"
+                enctype="multipart/form-data"
+                method="POST">
                 <span tal:content="structure python:here.openBlankForm(request)" />
             </form>
         </tal:block_ispage>

--- a/Products/CMFPlomino/skins/cmfplomino_templates/OpenForm.pt
+++ b/Products/CMFPlomino/skins/cmfplomino_templates/OpenForm.pt
@@ -225,7 +225,10 @@
                 <h1 class="documentFirstHeading" tal:content="here/Title">Title</h1>
                 <div tal:replace="structure provider:plone.belowcontenttitle" />
                 <div tal:replace="structure provider:plone.abovecontentbody" />
-                <form id="plomino_form" tal:attributes="name here/id" method="POST">
+                <form id="plomino_form"
+                    tal:attributes="name here/id"
+                    enctype="multipart/form-data"
+                    method="POST">
                     <span tal:content="structure python:here.openBlankForm(request)" />
                 </form>
                 <div tal:replace="structure provider:plone.belowcontentbody" />


### PR DESCRIPTION
E.g. if you want to submit a page form in order to act on submitted data
from computed fields or events without automatically creating a
document.

The enctype is needed to handle File fields.
