### PR TITLE
This applies to *multi*-select fields, not *all* select fields

### DIFF
--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -1126,7 +1126,9 @@ class PlominoForm(ATFolder):
                                 process_attachments,
                                 validation_mode=validation_mode)
                         if f.getFieldType() == 'SELECTION':
-                            v = asList(v)
+                            if f.getSettings().widget in [
+                                    'MULTISELECT', 'CHECKBOX', 'PICKLIST']:
+                                v = asList(v)
                         doc.setItem(fieldName, v)
                 else:
                     # The field was not submitted, probably because it is


### PR DESCRIPTION
Fix lame implementation ... no reason to always make single select fields lists. 
