### PR TITLE
Fix for issue #437

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(name='Products.CMFPlomino',
           'plone.app.jquery',
           'zope.app.component',  # Helps Plone 4.0, should not hurt elsewhere.
           'zope.globalrequest',  # This one too.
+          'plone.resource',
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
This makes the dependency on plone.resource explicit, so that
bin/test loads it in its path even when in the default buildout.
