### PR TITLE
Split key column from sort column; respect `DoNotReindex` when adding column

### DIFF
--- a/Products/CMFPlomino/PlominoView.py
+++ b/Products/CMFPlomino/PlominoView.py
@@ -86,10 +86,23 @@ returns the current Plomino document."""),
             description="Column used to sort the view",
             format='select',
             label_msgid=_('CMFPlomino_label_SortColumn', default="Sort column"),
-            description_msgid=_('CMFPlomino_help_SortColumn', default="Column used to sort the view"),
+            description_msgid=_('CMFPlomino_help_SortColumn', default="Column used to sort the view, and by default for key lookup"),
             i18n_domain='CMFPlomino',
         ),
-        vocabulary="SortColumn_vocabulary",
+        vocabulary="Column_vocabulary",
+        schemata="Sorting",
+    ),
+    StringField(
+        name='KeyColumn',
+        widget=SelectionWidget(
+            label="Key column",
+            description="Column used for key lookup",
+            format='select',
+            label_msgid=_('CMFPlomino_label_KeyColumn', default="Key column"),
+            description_msgid=_('CMFPlomino_help_KeyColumn', default="Column used for key lookup, if different from sort column"),
+            i18n_domain='CMFPlomino',
+        ),
+        vocabulary="Column_vocabulary",
         schemata="Sorting",
     ),
     BooleanField(
@@ -424,9 +437,11 @@ class PlominoView(ATFolder):
         """ Post create
         """
         db = self.getParentDatabase()
+        refresh = not db.DoNotReindex
         db.getIndex().createSelectionIndex(
-                'PlominoViewFormula_'+self.getViewName())
-        if not db.DoNotReindex:
+                'PlominoViewFormula_'+self.getViewName(),
+                refresh=refresh)
+        if refresh:
             self.getParentDatabase().getIndex().refresh()
 
     security.declarePublic('declareColumn')
@@ -680,21 +695,30 @@ class PlominoView(ATFolder):
 
     security.declarePublic('getDocumentsByKey')
     def getDocumentsByKey(self, key, getObject=True):
-        """ Get documents where the sorted column value matches the given key.
+        """ Get documents where key or sorted column matches the given key
         """
         index = self.getParentDatabase().getIndex()
-        sortindex = self.getSortColumn()
-        if not sortindex:
+        keycolumn = self.getKeyColumn()
+        sortcolumn = self.getSortColumn()
+
+        if not (keycolumn or sortcolumn):
             return []
 
-        sortindex = self.getIndexKey(sortindex)
+        query = {'PlominoViewFormula_%s' % self.getViewName(): True}
+        sortkey = None
+        if keycolumn:
+            query[self.getIndexKey(keycolumn)] = key
+        elif sortcolumn:
+            sortkey = self.getIndexKey(sortcolumn)
+            query[sortkey] = key
+
         results = index.dbsearch(
-                    {'PlominoViewFormula_%s' % self.getViewName(): True,
-                    sortindex: key},
-                sortindex,
+                query,
+                sortkey,
                 self.getReverseSorting())
 
         if getObject:
+            # TODO: keep lazy
             return [d.getObject() for d in results]
         else:
             return results
@@ -777,7 +801,7 @@ class PlominoView(ATFolder):
                 key = ''
         return key
 
-    def SortColumn_vocabulary(self):
+    def Column_vocabulary(self):
         return [''] + [c.id for c in self.getColumns()]
 
 registerType(PlominoView, PROJECTNAME)

--- a/Products/CMFPlomino/tests/plomino.txt
+++ b/Products/CMFPlomino/tests/plomino.txt
@@ -637,6 +637,15 @@ field::
     >>> 'field2' in db.getIndex().indexes()
     True
 
+If we don't want the sort column to double as the key column, we can set
+another column as key column::
+
+    >>> db.view1.setKeyColumn('col2')
+    >>> len(db.view1.getDocumentsByKey('hello'))
+    0
+    >>> len(db.view1.getDocumentsByKey('My favorite song is Ho Chi Minh City calling by The Clash'))
+    1
+
 Import/export design
 ---------------------
 


### PR DESCRIPTION
E.g. a view has documents of different types.
We want to sort on `(doctype, date)` but key on `ref`.

Also: respect `DoNotReindex` when adding a column.
