### PR TITLE
Use the getItem API

### DIFF
--- a/Products/CMFPlomino/PlominoAccessControl.py
+++ b/Products/CMFPlomino/PlominoAccessControl.py
@@ -258,6 +258,7 @@ class PlominoAccessControl(Persistent):
     def isCurrentUserReader(self, doc):
         """ Does the current user have read permission on the db
         (so Plone security is preserved)?
+
         If Plomino_Readers is defined on the doc, is he part of it?
         """
         isreader = False

--- a/Products/CMFPlomino/PlominoDocument.py
+++ b/Products/CMFPlomino/PlominoDocument.py
@@ -334,7 +334,7 @@ class PlominoDocument(CatalogAware, CMFBTreeFolder, Contained):
         """ Return list of readers; if none set, everyone can read.
         """
         if self.hasItem('Plomino_Readers'):
-            return asList(self.Plomino_Readers)
+            return asList(self.getItem('Plomino_Readers'))
         else:
             return ['*']
 


### PR DESCRIPTION
getItem does a deepcopy. This ensures that changes to Plomino_Readers
needs to be persisted using setItem. Let's use getItem consistently,
so that assumptions when working with items can be consistent.
