### PR TITLE
Fix the value to accept the value with space.

### DIFF
--- a/Products/CMFPlomino/skins/cmfplomino_templates/SELECTIONFieldEdit.pt
+++ b/Products/CMFPlomino/skins/cmfplomino_templates/SELECTIONFieldEdit.pt
@@ -70,8 +70,8 @@
 
 		 	function ${fieldid}_add_row(data) {
 		 		var tablebody = jQuery('#${fieldid}_table_result > tbody');
-		 		//if (tablebody.has('input[value=' + data[0] + ']').length == 0) {
-		 		if (jQuery('#${fieldid}_table_result > tbody:has(input[value=' + data[0] + '])').length == 0) {
+		 		//if (tablebody.has('input[value=\'' + data[0] + '\']').length == 0) {
+		 		if (jQuery('#${fieldid}_table_result > tbody:has(input[value=\'' + data[0] + '\'])').length == 0) {
 		 			//tablebody.children().has('input[value=]').remove()
 		 			jQuery('#${fieldid}_table_result > tbody > *:has(input[value=])').remove()
 			 		var row = jQuery('<tr><td><img alt=\'Remove\' src=\'list-remove.png\' style=\'cursor: pointer\' onclick=\'${fieldid}_delete_row(this)\' />' +


### PR DESCRIPTION
To fix https://github.com/plomino/Plomino/issues/523

jQuery('#testfield_table_result > tbody:has(input[value=' + data[0] + '])') need to change to jQuery('#${fieldid}_table_result > tbody:has(input[value=\'' + data[0] + '\'])')

for example:
jQuery('#${fieldid}_table_result > tbody:has(input[value="Spam Box"])')
