### PR TITLE
don't format number if number is None

### DIFF
--- a/Products/CMFPlomino/fields/number.py
+++ b/Products/CMFPlomino/fields/number.py
@@ -116,7 +116,7 @@ class NumberField(BaseField):
         if v not in (None, "") and self.format:
             try:
                 str_v = self.format % v
-            except:
+            except TypeError:
                 str_v = "Formatting error"
         else:
             str_v = str(v)


### PR DESCRIPTION
Goal of this change is to don't show 'formatError' if the number is equal to None or "" (and let it empty).
