### PR TITLE
Remove XML comment around JavaScript code

### DIFF
--- a/Products/CMFPlomino/skins/cmfplomino_templates/global_statusmessage.pt
+++ b/Products/CMFPlomino/skins/cmfplomino_templates/global_statusmessage.pt
@@ -29,7 +29,6 @@
         <pre></pre>
     </div>
     <script type="text/javascript">
-    <!--
         function showTraceback(el, formula_path) {
             msg = $(el).children().filter(":first").html();
             popup = $("#plominoTracebackPopup").clone();
@@ -48,7 +47,6 @@
         $(document).ready(function () {
 			$("#plominoMessages").load("./statusmessage_load #plonePortalMessages");
 		});
-	-->
     </script>
 
 </tal:block>


### PR DESCRIPTION
Internet Explorer throws an error if JS code is in XML comments when run through jQuery.globalEval on jQuery > 1.6.x (Plone 4.3.x). This is a problem in Plone with popupForms like the login form which do an AJAX request and then run all code on the result through jQuery.globalEval.

See also: http://stackoverflow.com/questions/7072060/after-upgrading-to-jquery-1-6-2-globaleval-throws-an-error-when-trying-to-execu
