### PR TITLE
Fix #563 clear IE cache for status message load page during ajax call.

### DIFF
--- a/Products/CMFPlomino/skins/cmfplomino_templates/global_statusmessage.pt
+++ b/Products/CMFPlomino/skins/cmfplomino_templates/global_statusmessage.pt
@@ -45,7 +45,7 @@
         	popup.dialog({show: "blind", height: 430, width: 530});
         }
         $(document).ready(function () {
-			$("#plominoMessages").load("./statusmessage_load #plonePortalMessages");
+			$("#plominoMessages").load("./statusmessage_load?" + new Date().getTime() + " #plonePortalMessages");
 		});
     </script>
 


### PR DESCRIPTION
That is due to statusmessage_load was cached by IE. Explanation at http://stackoverflow.com/questions/1061525/jquerys-load-not-working-in-ie-but-fine-in-firefox-chrome-and-safari
