### PR TITLE
Fix bug in _handleLabels decode special chars

### DIFF
--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -13,7 +13,8 @@ __author__ = """Eric BREHAULT <eric.brehault@makina-corpus.org>"""
 __docformat__ = 'plaintext'
 
 # Standard
-import re
+import re, sys
+sys_enc = sys.getfilesystemencoding()
 
 import logging
 logger = logging.getLogger('Plomino')
@@ -560,7 +561,7 @@ class PlominoForm(ATFolder):
                 fn = d['fieldname_or_label']
                 field = self.getFormField(fn)
                 if field:
-                    label = field.Title()
+                    label = field.Title().decode(sys_enc)
                 else:
                     continue
 


### PR DESCRIPTION
I noticed that using labels in PlominoForms with fields that has title with accents in it causes errors.
I found this solution but I'm not sure it is the best or more elegant.
