### PR TITLE
another encoding problem, this time regarding HTMLAttributes

### DIFF
--- a/Products/CMFPlomino/PlominoField.py
+++ b/Products/CMFPlomino/PlominoField.py
@@ -17,6 +17,8 @@ from Products.Archetypes.atapi import *
 from zope.interface import implements
 import interfaces
 
+from Products.CMFPlomino.PlominoUtils import asUnicode
+
 from Products.CMFPlomino import fields, plomino_profiler
 
 from Products.CMFDynamicViewFTI.browserdefault import BrowserDefaultMixin
@@ -293,7 +295,7 @@ class PlominoField(BaseContent, BrowserDefaultMixin):
                 )
                 html = ' '.join([
                     html[:injection_position],
-                    html_attributes,
+                    asUnicode(html_attributes),
                     html[injection_position:],
                 ])
             return html


### PR DESCRIPTION
As happened with the PlominoLabels using PlominoField titles with accents, the same problem occurs introducing string values with accents in HTMLAtributeFormula result.
