### PR TITLE
Fix #625 displayDocument() creates TemporaryDocument if no Page exists

### DIFF
--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -825,9 +825,14 @@ class PlominoForm(ATFolder):
         for hidewhen in self.getHidewhenFormulas():
             hidewhenName = hidewhen.id
             try:
+                if doc is None:
+                    target = self
+                else:
+                    target = doc
+
                 result = self.runFormulaScript(
                     SCRIPT_ID_DELIMITER.join(['hidewhen', self.id, hidewhen.id, 'formula']),
-                    doc,
+                    target,
                     hidewhen.Formula)
             except PlominoScriptException, e:
                 if not silent_error:

--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -825,11 +825,6 @@ class PlominoForm(ATFolder):
         for hidewhen in self.getHidewhenFormulas():
             hidewhenName = hidewhen.id
             try:
-                if doc is None:
-                    target = self
-                else:
-                    target = doc
-
                 result = self.runFormulaScript(
                     SCRIPT_ID_DELIMITER.join(['hidewhen', self.id, hidewhen.id, 'formula']),
                     doc,

--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -650,12 +650,14 @@ class PlominoForm(ATFolder):
         # remove the hidden content
         if doc is None:
             db = self.getParentDatabase()
-            doc = getTemporaryDocument(
+            hidewhen_target = getTemporaryDocument(
                 db,
                 self,
                 self.REQUEST
             )
-        html_content = self.applyHideWhen(doc, silent_error=False)
+        else:
+            hidewhen_target = doc
+        html_content = self.applyHideWhen(hidewhen_target, silent_error=False)
         if request:
             parent_form_ids = request.get('parent_form_ids', [])
             if parent_form_id:

--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -648,6 +648,13 @@ class PlominoForm(ATFolder):
         """ Display the document using the form's layout
         """
         # remove the hidden content
+        if doc is None:
+            db = self.getParentDatabase()
+            doc = getTemporaryDocument(
+                db,
+                self,
+                self.REQUEST
+            )
         html_content = self.applyHideWhen(doc, silent_error=False)
         if request:
             parent_form_ids = request.get('parent_form_ids', [])
@@ -815,21 +822,12 @@ class PlominoForm(ATFolder):
         html_content = self._get_html_content()
 
         # remove the hidden content
-        if doc is None:
-            db = self.getParentDatabase()
-            target = getTemporaryDocument(
-                db,
-                self,
-                self.REQUEST
-            )
-        else:
-            target = doc
         for hidewhen in self.getHidewhenFormulas():
             hidewhenName = hidewhen.id
             try:
                 result = self.runFormulaScript(
                     SCRIPT_ID_DELIMITER.join(['hidewhen', self.id, hidewhen.id, 'formula']),
-                    target,
+                    doc,
                     hidewhen.Formula)
             except PlominoScriptException, e:
                 if not silent_error:


### PR DESCRIPTION
I have moved the creation of TemporaryDocument from inside applyHideWhen as it is called recursively when a temporary document is created. Instead, the temporary document is created on displayDocument if no doc was passed in.