### PR TITLE
[WIP] Group fields and return field ids with validation errors

### DIFF
--- a/Products/CMFPlomino/PlominoDocument.py
+++ b/Products/CMFPlomino/PlominoDocument.py
@@ -403,7 +403,7 @@ class PlominoDocument(CatalogAware, CMFBTreeFolder, Contained):
             e.reportError('Form submitted, but beforeSave formula failed')
 
         if error:
-            errors.append(error)
+            errors.append({'field': 'beforeSave', 'error': error})
 
         # if errors, stop here, and notify errors to user
         if errors:

--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -593,12 +593,14 @@ class PlominoForm(ATFolder):
         for label_node in d("span.plominoLabelClass"):
 
             # work out the fieldid the label is for, and its text
-            label_text = None
+            # we could have hide whens or other nodes in our label. filter them out
+            label_text = pq(label_node).clone().children().remove().end().text()
             try:
-                field_id, label_text = pq(label_node).text().split(':',1)
+                field_id, label_text = label_text.split(':',1)
                 label_text = label_text.strip()
             except:
-                field_id = pq(label_node).text()
+                field_id = label_text
+                label_text = None
             field_id = field_id.strip()
             field = self.getFormField(field_id)
             if field is None:

--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -623,7 +623,7 @@ class PlominoForm(ATFolder):
                         break
 
             field_type = field.getFieldType()
-            if field_type != 'DATETIME':
+            if hasattr(field.getSettings(), 'widget'):
                 widget_name = field.getSettings().widget
 
             compound_widget = (field_type == 'DATETIME' or

--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -632,7 +632,8 @@ class PlominoForm(ATFolder):
                         # found our field
                         found_in_sibling = True
                         to_find.remove(field)
-                    elif field_node:
+                    elif field_node and togroup:
+                        # found a field in our group thats not ours
                         # disolve grouping
                         togroup = found = []
                         break
@@ -686,7 +687,6 @@ class PlominoForm(ATFolder):
             else:
                 # we don't want to group a table row or list elements
                 togroup = []
-                import pdb; pdb.set_trace()
             #wrapped = pq(togroup).wrap_all(grouping)
 
             # my own wrap method
@@ -696,7 +696,6 @@ class PlominoForm(ATFolder):
                     ng = pq(grouping).insert_before(pq(togroup).eq(0))
                     pq(ng).append(pq(togroup))
                 except:
-                    import pdb; pdb.set_trace()
                     raise
                 if field.getMandatory():
                     pq(ng).add_class("required")

--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -638,15 +638,13 @@ class PlominoForm(ATFolder):
             else:
                 legend = "<span class='legend'></span>"
             grouping = ""
-            if togroup and pq(togroup).is_("span"):
+            #TODO: is testing the first element enough?
+            if togroup and pq(togroup).eq(0).is_("span"):
                 # we want to wrap in a div
                 grouping = '<span class="plominoFieldGroup"></span>'
-            elif togroup and (pq(togroup).is_("div") or pq(togroup).is_("p")):
+            elif togroup and pq(togroup).eq(0).is_("div,p"):
                 if compound_widget and editmode:
-                    if field.getMandatory():
-                        grouping = "<fieldset class='required'></fieldset>"
-                    else:
-                        grouping = "<fieldset></fieldset>"
+                    grouping = "<fieldset></fieldset>"
                     legend = "<legend></legend>"
                 else:
                     grouping = '<div class="plominoFieldGroup"></div>'
@@ -664,6 +662,8 @@ class PlominoForm(ATFolder):
                 except:
                     import pdb; pdb.set_trace()
                     raise
+                if field.getMandatory():
+                    pq(ng).add_class("required")
 
             #switch the label last so insert_before works properly
             legend = pq(legend).append(label_text)

--- a/Products/CMFPlomino/skins/cmfplomino_templates/ErrorMessages.pt
+++ b/Products/CMFPlomino/skins/cmfplomino_templates/ErrorMessages.pt
@@ -16,7 +16,7 @@
     <div id="bodyContent" tal:define="asparam request/error|nothing">
     	<h1 i18n:domain="CMFPlomino" i18n:translate="Validation failed">Validation failed</h1>
 		<ul id="error_list" tal:condition="not:asparam" tal:repeat="e options/errors">
-			<li tal:content="structure e">error message</li>
+			<li tal:content="structure e/error">error message</li>
 		</ul>
 		<ul tal:condition="asparam">
 			<li tal:content="structure request/error">error message</li>

--- a/Products/CMFPlomino/skins/cmfplomino_templates/validation_messages.pt
+++ b/Products/CMFPlomino/skins/cmfplomino_templates/validation_messages.pt
@@ -32,7 +32,7 @@ $("#plomino_form").submit(function(){
             popup = $("#plominoValidationPopup").clone();
             message = "";
             $.each(data['errors'], function(index, value) {
-                message = message + value + "<br/>";
+                message = message + value['error'] + "<br/>";
             });
             $(popup).children("strong").html(message);
             popup.dialog({show: "blind", height: 350, width: 530});

--- a/Products/CMFPlomino/tests/layout.txt
+++ b/Products/CMFPlomino/tests/layout.txt
@@ -342,8 +342,8 @@ We could have two alternative labels using hidewhens.
     ...         title='is true', formula="True", isDynamicHidewhen=False)
     >>> db.frm1.field1.at_post_create_script()
     >>> db.frm1.setFormLayout("""
-    ... <p><span class="plominoLabelClass"><span class="plominoHidewhenClass">start:is_true</span> field1:my label <span class="plominoHidewhenClass">end:is_true</span></span></p>
-    ... <p><span class="plominoLabelClass"><span class="plominoHidewhenClass">start:is_false</span> field1:my label <span class="plominoHidewhenClass">end:is_false</span></span></p>
+    ... <p><span class="plominoLabelClass"><span class="plominoHidewhenClass">start:is_true</span> field1:true <span class="plominoHidewhenClass">end:is_true</span></span></p>
+    ... <p><span class="plominoLabelClass"><span class="plominoHidewhenClass">start:is_false</span> field1:false <span class="plominoHidewhenClass">end:is_false</span></span></p>
     ... <p><span class="plominoFieldClass">field1</span></p>
     ... """)
     >>> print pphtml(db.frm1.displayDocument(None, True, True))
@@ -351,11 +351,17 @@ We could have two alternative labels using hidewhens.
     <div class="plominoFieldGroup required">
      <p>
       <label for="field1">
-       my label
+       <span class="plominoHidewhenClass">start:is_true</span>
+        true
+       <span class="plominoHidewhenClass">end:is_true</span>
       </label>
      </p>
      <p>
-       Some help text
+      <label for="field1">
+       <span class="plominoHidewhenClass">start:is_false</span>
+        false
+       <span class="plominoHidewhenClass">end:is_false</span>
+      </label>
      </p>
      <p>
       <span>

--- a/Products/CMFPlomino/tests/layout.txt
+++ b/Products/CMFPlomino/tests/layout.txt
@@ -63,6 +63,26 @@ If labels are inline then no fieldset is used. A span is used instead.
       </span>
      </p>
 
+If no label text is specified then the field Title is used
+
+     >>> db.frm1.setFormLayout("""
+     ... <p><span class="plominoLabelClass">field1</span>
+     ... <span class="plominoFieldClass">field1</span></p>
+     ... """)
+     >>> print pphtml(db.frm1.displayDocument(None, True, True))
+     <input type="hidden" name="Form" value="frm1" />
+     <p>
+      <span class="plominoFieldGroup required">
+       <label for="field1">
+        Title for field1
+       </label>
+       <span>
+        <input type="text" id="field1" value="" name="field1" />
+       </span>
+      </span>
+     </p>
+
+
 If labels are different paragraphs then a fieldset won't be used but it will be grouped in a
 a grouping div. This can be useful to highlight an error message affecting the field as a whole.
 
@@ -109,6 +129,29 @@ if we have some text inbetween just as help text this will be preserved
        </span>
       </p>
      </div>
+
+It won't group when label and field are in a table
+     >>> db.frm1.setFormLayout("""
+     ... <table><tr><td><span class="plominoLabelClass">field1:my label</span></td>
+     ... <td><span class="plominoFieldClass">field1</span></td></tr></table>
+     ... """)
+     >>> print pphtml(db.frm1.displayDocument(None, True, True))
+     <input type="hidden" name="Form" value="frm1" />
+     <table>
+      <tr>
+       <td>
+        <label for="field1">
+         my label
+        </label>
+       </td>
+       <td>
+        <span>
+         <input type="text" id="field1" value="" name="field1" />
+        </span>
+       </td>
+      </tr>
+     </table>
+
 
 It's legal to have two labels for the same field
 
@@ -187,6 +230,110 @@ It will still group with a label on either side
       </label>
      </p>
     </div>
+
+ In the
+case of grouped inputs such as radio buttons or checkboxes, the group is
+enclosed in an HTML 'fieldset' element, and the label is rendered as an
+HTML 'legend' element.
+
+
+    >>> id = db.frm2.invokeFactory('PlominoField',
+    ...         id='guitarist',
+    ...         title='Title for guitarist',
+    ...         FieldType="TEXT",
+    ...         FieldMode="EDITABLE")
+    >>> db.frm2.guitarist.at_post_create_script()
+    >>> id = db.frm2.invokeFactory('PlominoField',
+    ...         id='bassist',
+    ...         title='Title for bassist',
+    ...         Mandatory='1',
+    ...         FieldType="SELECTION",
+    ...         FieldMode="EDITABLE")
+    >>> db.frm2.bassist.at_post_create_script()
+    >>> id = db.frm2.invokeFactory('PlominoField',
+    ...         id='drummer',
+    ...         title='Title for drummer',
+    ...         FieldType="SELECTION",
+    ...         FieldMode="EDITABLE")
+    >>> db.frm2.drummer.at_post_create_script()
+    >>> from Products.CMFPlomino.fields.text import ITextField
+    >>> from Products.CMFPlomino.fields.selection import ISelectionField
+    >>> db.frm2.setFormLayout("""3 <p>Who is the guitarist:
+    ... <span class="plominoLabelClass">guitarist</span></p>
+    ... <p><span class="plominoFieldClass">guitarist</span></p>
+    ... <p><span class="plominoLabelClass">bassist: Label for bassist</span></p>
+    ... <p><span class="plominoFieldClass">bassist</span></p>
+    ... <p><span class="plominoLabelClass">drummer</span></p>
+    ... <p><span class="plominoFieldClass">drummer</span></p>
+    ... """)
+    >>> adapted = ISelectionField(db.frm2.bassist)
+    >>> adapted.widget = "CHECKBOX"
+    >>> adapted.selectionlist = [u"John Paul Jones", u"Chris Chameleon"]
+    >>> adapted = ISelectionField(db.frm2.drummer)
+    >>> adapted.widget = "RADIO"
+    >>> adapted.selectionlist = [u"John Bonham", u"Princess Leonie"]
+    >>> print pphtml(db.frm2.displayDocument(None, True, True))
+    <input type="hidden" name="Form" value="frm2" />
+    3
+    <div class="plominoFieldGroup">
+     <p>
+      Who is the guitarist:
+      <label for="guitarist">
+       Title for guitarist
+      </label>
+     </p>
+     <p>
+      <span>
+       <input type="text" id="guitarist" value="" name="guitarist" />
+      </span>
+     </p>
+    </div>
+    <fieldset class="required">
+     <p>
+      <legend>
+       Label for bassist
+      </legend>
+     </p>
+     <p>
+      <span class="bassist-selectionfield">
+       <span>
+        <input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones" />
+        <label for="bassist-John Paul Jones">
+         John Paul Jones
+        </label>
+       </span>
+       <span>
+        <input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon" />
+        <label for="bassist-Chris Chameleon">
+         Chris Chameleon
+        </label>
+       </span>
+      </span>
+     </p>
+    </fieldset>
+    <fieldset>
+     <p>
+      <legend>
+       Title for drummer
+      </legend>
+     </p>
+     <p>
+      <span class="drummer-selectionfield">
+       <span>
+        <input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham" />
+        <label for="drummer-John Bonham">
+         John Bonham
+        </label>
+       </span>
+       <span>
+        <input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie" />
+        <label for="drummer-Princess Leonie">
+         Princess Leonie
+        </label>
+       </span>
+      </span>
+     </p>
+    </fieldset>
 
 
 We could have two alternative labels using hidewhens.
@@ -306,109 +453,6 @@ https://admin.pretagov.co.uk/05/mnt/www/DWP%20eforms/hardship-payment-1/About_yo
 <p><span class="plominoFieldClass"><span class="plominoHidewhenClass">end:serious_illness_affect</span></span></p>
 
 
- In the
-case of grouped inputs such as radio buttons or checkboxes, the group is
-enclosed in an HTML 'fieldset' element, and the label is rendered as an
-HTML 'legend' element.
-
-
-    >>> id = db.frm2.invokeFactory('PlominoField',
-    ...         id='guitarist',
-    ...         title='Title for guitarist',
-    ...         FieldType="TEXT",
-    ...         FieldMode="EDITABLE")
-    >>> db.frm2.guitarist.at_post_create_script()
-    >>> id = db.frm2.invokeFactory('PlominoField',
-    ...         id='bassist',
-    ...         title='Title for bassist',
-    ...         Mandatory='1',
-    ...         FieldType="SELECTION",
-    ...         FieldMode="EDITABLE")
-    >>> db.frm2.bassist.at_post_create_script()
-    >>> id = db.frm2.invokeFactory('PlominoField',
-    ...         id='drummer',
-    ...         title='Title for drummer',
-    ...         FieldType="SELECTION",
-    ...         FieldMode="EDITABLE")
-    >>> db.frm2.drummer.at_post_create_script()
-    >>> from Products.CMFPlomino.fields.text import ITextField
-    >>> from Products.CMFPlomino.fields.selection import ISelectionField
-    >>> db.frm2.setFormLayout("""3 <p>Who is the guitarist:
-    ... <span class="plominoLabelClass">guitarist</span></p>
-    ... <p><span class="plominoFieldClass">guitarist</span></p>
-    ... <p><span class="plominoLabelClass">bassist: Label for bassist</span></p>
-    ... <p><span class="plominoFieldClass">bassist</span></p>
-    ... <p><span class="plominoLabelClass">drummer</span></p>
-    ... <p><span class="plominoFieldClass">drummer</span></p>
-    ... """)
-    >>> adapted = ISelectionField(db.frm2.bassist)
-    >>> adapted.widget = "CHECKBOX"
-    >>> adapted.selectionlist = [u"John Paul Jones", u"Chris Chameleon"]
-    >>> adapted = ISelectionField(db.frm2.drummer)
-    >>> adapted.widget = "RADIO"
-    >>> adapted.selectionlist = [u"John Bonham", u"Princess Leonie"]
-    >>> print pphtml(db.frm2.displayDocument(None, True, True))
-    <input type="hidden" name="Form" value="frm2" />
-    3
-    <div class="plominoFieldGroup">
-     <p>
-      Who is the guitarist:
-      <label for="guitarist">
-       Title for guitarist
-      </label>
-     </p>
-     <p>
-      <span>
-       <input type="text" id="guitarist" value="" name="guitarist" />
-      </span>
-     </p>
-    </div>
-    <fieldset class="required">
-     <p>
-      <legend>
-       Label for bassist
-      </legend>
-     </p>
-     <p>
-      <span class="bassist-selectionfield">
-       <span>
-        <input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones" />
-        <label for="bassist-John Paul Jones">
-         John Paul Jones
-        </label>
-       </span>
-       <span>
-        <input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon" />
-        <label for="bassist-Chris Chameleon">
-         Chris Chameleon
-        </label>
-       </span>
-      </span>
-     </p>
-    </fieldset>
-    <fieldset>
-     <p>
-      <legend>
-       Title for drummer
-      </legend>
-     </p>
-     <p>
-      <span class="drummer-selectionfield">
-       <span>
-        <input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham" />
-        <label for="drummer-John Bonham">
-         John Bonham
-        </label>
-       </span>
-       <span>
-        <input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie" />
-        <label for="drummer-Princess Leonie">
-         Princess Leonie
-        </label>
-       </span>
-      </span>
-     </p>
-    </fieldset>
 
 .. todo:: test text area
 

--- a/Products/CMFPlomino/tests/layout.txt
+++ b/Products/CMFPlomino/tests/layout.txt
@@ -53,7 +53,7 @@ If labels are inline then no fieldset is used. A span is used instead.
      >>> print pphtml(db.frm1.displayDocument(None, True, True))
      <input type="hidden" name="Form" value="frm1" />
      <p>
-      <span class="plominoFieldGroup">
+      <span class="plominoFieldGroup required">
        <label for="field1">
         my label
        </label>
@@ -72,7 +72,7 @@ a grouping div. This can be useful to highlight an error message affecting the f
      ... """)
      >>> print pphtml(db.frm1.displayDocument(None, True, True))
      <input type="hidden" name="Form" value="frm1" />
-     <div class="plominoFieldGroup">
+     <div class="plominoFieldGroup required">
       <p>
        <label for="field1">
         my label
@@ -94,7 +94,7 @@ if we have some text inbetween just as help text this will be preserved
      ... """)
      >>> print pphtml(db.frm1.displayDocument(None, True, True))
      <input type="hidden" name="Form" value="frm1" />
-     <div class="plominoFieldGroup">
+     <div class="plominoFieldGroup required">
       <p>
        <label for="field1">
         my label
@@ -159,8 +159,6 @@ case of grouped inputs such as radio buttons or checkboxes, the group is
 enclosed in an HTML 'fieldset' element, and the label is rendered as an
 HTML 'legend' element.
 
-Text field:
-The default text widget is a basic HTML text input::
 
     >>> id = db.frm2.invokeFactory('PlominoField',
     ...         id='guitarist',
@@ -185,11 +183,11 @@ The default text widget is a basic HTML text input::
     >>> from Products.CMFPlomino.fields.selection import ISelectionField
     >>> db.frm2.setFormLayout("""3 <p>Who is the guitarist:
     ... <span class="plominoLabelClass">guitarist</span></p>
-    ... <span class="plominoFieldClass">guitarist</span></p>
-    ... <span class="plominoLabelClass">bassist: Label for bassist</span></p>
-    ... <span class="plominoFieldClass">bassist</span></p>
-    ... <span class="plominoLabelClass">drummer</span></p>
-    ... <span class="plominoFieldClass">drummer</span></p>
+    ... <p><span class="plominoFieldClass">guitarist</span></p>
+    ... <p><span class="plominoLabelClass">bassist: Label for bassist</span></p>
+    ... <p><span class="plominoFieldClass">bassist</span></p>
+    ... <p><span class="plominoLabelClass">drummer</span></p>
+    ... <p><span class="plominoFieldClass">drummer</span></p>
     ... """)
     >>> adapted = ISelectionField(db.frm2.bassist)
     >>> adapted.widget = "CHECKBOX"
@@ -207,84 +205,64 @@ The default text widget is a basic HTML text input::
        Title for guitarist
       </label>
      </p>
-     <span>
-      <input type="text" id="guitarist" value="" name="guitarist" />
-     </span>
-     <fieldset>
-      <legend class="required">
+     <p>
+      <span>
+       <input type="text" id="guitarist" value="" name="guitarist" />
+      </span>
+     </p>
+    </div>
+    <fieldset class="required">
+     <p>
+      <legend>
        Label for bassist
       </legend>
-      <span>
-       <input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones" />
-       <label for="bassist-John Paul Jones">
-        John Paul Jones
-       </label>
-       <input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon" />
-       <label for="bassist-Chris Chameleon">
-        Chris Chameleon
-       </label>
+     </p>
+     <p>
+      <span class="bassist-selectionfield">
+       <span>
+        <input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones" />
+        <label for="bassist-John Paul Jones">
+         John Paul Jones
+        </label>
+       </span>
+       <span>
+        <input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon" />
+        <label for="bassist-Chris Chameleon">
+         Chris Chameleon
+        </label>
+       </span>
       </span>
-     </fieldset>
-     <fieldset>
+     </p>
+    </fieldset>
+    <fieldset>
+     <p>
       <legend>
        Title for drummer
       </legend>
-      <span>
-      <input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham" />
-      <label for="drummer-John Bonham">
-       John Bonham
-      </label>
-      <input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie" />
-      <label for="drummer-Princess Leonie">
-       Princess Leonie
-      </label>
-     </span>
+     </p>
+     <p>
+      <span class="drummer-selectionfield">
+       <span>
+        <input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham" />
+        <label for="drummer-John Bonham">
+         John Bonham
+        </label>
+       </span>
+       <span>
+        <input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie" />
+        <label for="drummer-Princess Leonie">
+         Princess Leonie
+        </label>
+       </span>
+      </span>
+     </p>
     </fieldset>
 
-   >>> adapted = ITextField(db.frm2.guitarist)
-    >>> adapted.widget="TEXTAREA"
-    >>> print pphtml(db.frm2.displayDocument(None, True, True))
-    <input type="hidden" name="Form" value="frm2" />
-    3
-    <p>
-     Who is the guitarist:
-     <label for="guitarist">
-      Title for guitarist
-     </label>
-    </p>
-    <span>
-     <textarea id="guitarist" name="guitarist">
-     </textarea>
-    </span>
-    <fieldset>
-     <legend class="required">
-      Label for bassist
-     </legend>
-     <span>
-      <input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones" />
-      <label for="bassist-John Paul Jones">
-       John Paul Jones
-      </label>
-      <input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon" />
-      <label for="bassist-Chris Chameleon">
-       Chris Chameleon
-      </label>
-     </span>
-    </fieldset>
-    <fieldset>
-     <legend>
-      Title for drummer
-     </legend>
-     <span>
-      <input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham" />
-      <label for="drummer-John Bonham">
-       John Bonham
-      </label>
-      <input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie" />
-      <label for="drummer-Princess Leonie">
-       Princess Leonie
-      </label>
-     </span>
-    </fieldset>
+.. todo:: test text area
 
 .. todo:: We need a test for a selection list with no value in edit mode. It should not render a label.
+
+.. todo:: test labels below fields
+
+.. todo:: test labels without fieldid
+

--- a/Products/CMFPlomino/tests/layout.txt
+++ b/Products/CMFPlomino/tests/layout.txt
@@ -1,0 +1,290 @@
+Plomino Layout tests
+=========================
+
+We need to test code for
+ - automatically creating fieldsets
+ - doing labels
+ - handling labels and hidewhens
+ - doing clean up of various non-useful plomino style combinations
+
+
+>>> from lxml import etree, html
+>>> #pphtml = lambda myhtml: etree.tostring(html.fromstring(myhtml.replace('\t','').replace('\n','')), encoding='unicode', pretty_print=True)
+>>> from BeautifulSoup import BeautifulSoup; pphtml = lambda myhtml: BeautifulSoup(myhtml).prettify()
+
+Let's start testing::
+
+    >>> portal = layer['portal']
+    >>> db = portal.mydb
+    >>> id = db.invokeFactory('PlominoForm', id='frm1', title='Form 1')
+    >>> id = db.invokeFactory('PlominoForm', id='frm2', title='Form 2')
+    >>> db.frm1 == db.getForm('frm1')
+    True
+
+    >>> id = db.frm1.invokeFactory('PlominoField', id='field1',
+    ...         title='Title for field1',
+    ...         Mandatory='1',
+    ...         FieldType="TEXT",
+    ...         FieldMode="EDITABLE")
+    >>> db.frm1.field1.at_post_create_script()
+    >>> db.frm1.setFormLayout("""1 <p>please enter a value for field1:
+    ... <span class="plominoFieldClass">field1</span></p>""")
+    >>> print pphtml(db.frm1.displayDocument(None, True, True))
+    <input type="hidden" name="Form" value="frm1" />
+    1
+    <p>
+      please enter a value for field1:
+      <span>
+        <input type="text" id="field1" value="" name="field1" />
+      </span>
+    </p>
+
+
+
+For accessibility purposes, a label may be provided for a field. In the case
+of single inputs, the label is rendered as an HTML 'label' element.
+
+If labels are inline then no fieldset is used. A span is used instead.
+
+     >>> db.frm1.setFormLayout("""
+     ... <p><span class="plominoLabelClass">field1:my label</span>
+     ... <span class="plominoFieldClass">field1</span></p>
+     ... """)
+     >>> print pphtml(db.frm1.displayDocument(None, True, True))
+     <input type="hidden" name="Form" value="frm1" />
+     <p>
+      <span class="plominoFieldGroup">
+       <label for="field1">
+        my label
+       </label>
+       <span>
+        <input type="text" id="field1" value="" name="field1" />
+       </span>
+      </span>
+     </p>
+
+If labels are different paragraphs then a fieldset won't be used but it will be grouped in a
+a grouping div. This can be useful to highlight an error message affecting the field as a whole.
+
+     >>> db.frm1.setFormLayout("""
+     ... <p><span class="plominoLabelClass">field1:my label</span></p>
+     ... <p><span class="plominoFieldClass">field1</span></p>
+     ... """)
+     >>> print pphtml(db.frm1.displayDocument(None, True, True))
+     <input type="hidden" name="Form" value="frm1" />
+     <div class="plominoFieldGroup">
+      <p>
+       <label for="field1">
+        my label
+       </label>
+      </p>
+      <p>
+       <span>
+        <input type="text" id="field1" value="" name="field1" />
+       </span>
+      </p>
+     </div>
+
+if we have some text inbetween just as help text this will be preserved
+
+     >>> db.frm1.setFormLayout("""
+     ... <p><span class="plominoLabelClass">field1:my label</span></p>
+     ... <p>Some help text</p>
+     ... <p><span class="plominoFieldClass">field1</span></p>
+     ... """)
+     >>> print pphtml(db.frm1.displayDocument(None, True, True))
+     <input type="hidden" name="Form" value="frm1" />
+     <div class="plominoFieldGroup">
+      <p>
+       <label for="field1">
+        my label
+       </label>
+      </p>
+      <p>
+        Some help text
+      </p>
+      <p>
+       <span>
+        <input type="text" id="field1" value="" name="field1" />
+       </span>
+      </p>
+     </div>
+
+
+
+<div>
+<h3><span>About Universal Credit</span></h3>
+<p><span class="plominoLabelClass"><span class="plominoHidewhenClass">start:Not_Single</span> UniversalCreditQuestion: Are you getting Universal Credit or have you applied for it?<span class="plominoHidewhenClass">end:Not_Single</span></span></p>
+<p><span class="plominoLabelClass"><span class="plominoHidewhenClass">start:Not_Partnered</span>UniversalCreditQuestion: Are you or your partner getting Univeral Credit or have either of you applied for it?<span class="plominoHidewhenClass">end:Not_Partnered</span><br /></span></p>
+<p class=" "><span><span class="plominoFieldClass">UniversalCreditQuestion</span></span></p>
+</div>
+<p><span><br /></span></p>
+<p>Ê</p>
+
+
+<h2>About what you need</h2>
+<p class=" "><strong>Applying for a loan does not mean you will get one. It is recommended you do not spend the money you have applied for until we have notified you of our decision</strong></p>
+<p><span>The minimum amount you can apply for is </span><strong>£100</strong></p>
+<p><span><span>The maximum amount for a </span><span>c</span><span>ouple </span><span>without children or </span><span>dependent</span><span>Ê</span><span>young pe</span><span>rsons is </span><strong>£464</strong></span></p>
+<p><span><span>The maximum amount for a one or two parent family with</span><span> children or</span><span> dependent</span><span> young p</span><span>ersons</span><span>Ê</span><span>is </span><strong>£812</strong></span></p>
+<p>We use dependent young people to meanÊyoung people aged 16, 17, 18 or 19 that you are getting child benefit for.</p>
+<p><strong>We cannot make a payment for a loan if you already owe £1,500 to Social Fund for a Crisis Loan or Budgeting Loan combined.</strong></p>
+<p><strong><span>If you already owe money to social fund, this will effect how much we can pay you.</span></strong></p>
+<p><strong><span>Total amount you want to apply for £<span class="plominoFieldClass">loanamount</span></span></strong></p>
+
+
+
+<p><span class="plominoLabelClass">disabilitypaymentpartner:Does you partner look after someone who is getting, or waiting to hear about:</span></p>
+<ul class="listTypeCircle">
+<li>Attendance Allowance</li>
+<li>Disability Living Allowance for personal care at the middle or higherÊrate</li>
+<li>Persoanl Independence Payment for personal care atÊthe standard or enhanced rate?</li>
+</ul>
+<p><span class="plominoFieldClass">disabilitypaymentpartner</span></p>
+<p><span class="plominoFieldClass"><span class="plominoHidewhenClass"><span class="plominoHidewhenClass">start:disability_payment_partner</span></span></span></p>
+
+https://admin.pretagov.co.uk/05/mnt/www/DWP%20eforms/hardship-payment-1/About_your_health_serious_illness/view
+
+<h2>ÊSerious illness</h2>
+<p><span class="plominoLabelClass">seriousillness:AreÊyou suffering from a serious illness?</span></p>
+<p><span class="plominoFieldClass">seriousillness</span></p>
+<p><span class="plominoFieldClass"><span class="plominoHidewhenClass">start:serious_illness_affect</span></span></p>
+<p><span class="plominoLabelClass">howitaffects:What is your serious illness and how does it affect you?</span></p>
+<p><span class="plominoFieldClass">howitaffects</span></p>
+<p><span class="plominoFieldClass"><span class="plominoHidewhenClass">end:serious_illness_affect</span></span></p>
+
+
+ In the
+case of grouped inputs such as radio buttons or checkboxes, the group is
+enclosed in an HTML 'fieldset' element, and the label is rendered as an
+HTML 'legend' element.
+
+Text field:
+The default text widget is a basic HTML text input::
+
+    >>> id = db.frm2.invokeFactory('PlominoField',
+    ...         id='guitarist',
+    ...         title='Title for guitarist',
+    ...         FieldType="TEXT",
+    ...         FieldMode="EDITABLE")
+    >>> db.frm2.guitarist.at_post_create_script()
+    >>> id = db.frm2.invokeFactory('PlominoField',
+    ...         id='bassist',
+    ...         title='Title for bassist',
+    ...         Mandatory='1',
+    ...         FieldType="SELECTION",
+    ...         FieldMode="EDITABLE")
+    >>> db.frm2.bassist.at_post_create_script()
+    >>> id = db.frm2.invokeFactory('PlominoField',
+    ...         id='drummer',
+    ...         title='Title for drummer',
+    ...         FieldType="SELECTION",
+    ...         FieldMode="EDITABLE")
+    >>> db.frm2.drummer.at_post_create_script()
+    >>> from Products.CMFPlomino.fields.text import ITextField
+    >>> from Products.CMFPlomino.fields.selection import ISelectionField
+    >>> db.frm2.setFormLayout("""3 <p>Who is the guitarist:
+    ... <span class="plominoLabelClass">guitarist</span></p>
+    ... <span class="plominoFieldClass">guitarist</span></p>
+    ... <span class="plominoLabelClass">bassist: Label for bassist</span></p>
+    ... <span class="plominoFieldClass">bassist</span></p>
+    ... <span class="plominoLabelClass">drummer</span></p>
+    ... <span class="plominoFieldClass">drummer</span></p>
+    ... """)
+    >>> adapted = ISelectionField(db.frm2.bassist)
+    >>> adapted.widget = "CHECKBOX"
+    >>> adapted.selectionlist = [u"John Paul Jones", u"Chris Chameleon"]
+    >>> adapted = ISelectionField(db.frm2.drummer)
+    >>> adapted.widget = "RADIO"
+    >>> adapted.selectionlist = [u"John Bonham", u"Princess Leonie"]
+    >>> print pphtml(db.frm2.displayDocument(None, True, True))
+    <input type="hidden" name="Form" value="frm2" />
+    3
+    <div class="plominoFieldGroup">
+     <p>
+      Who is the guitarist:
+      <label for="guitarist">
+       Title for guitarist
+      </label>
+     </p>
+     <span>
+      <input type="text" id="guitarist" value="" name="guitarist" />
+     </span>
+     <fieldset>
+      <legend class="required">
+       Label for bassist
+      </legend>
+      <span>
+       <input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones" />
+       <label for="bassist-John Paul Jones">
+        John Paul Jones
+       </label>
+       <input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon" />
+       <label for="bassist-Chris Chameleon">
+        Chris Chameleon
+       </label>
+      </span>
+     </fieldset>
+     <fieldset>
+      <legend>
+       Title for drummer
+      </legend>
+      <span>
+      <input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham" />
+      <label for="drummer-John Bonham">
+       John Bonham
+      </label>
+      <input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie" />
+      <label for="drummer-Princess Leonie">
+       Princess Leonie
+      </label>
+     </span>
+    </fieldset>
+
+   >>> adapted = ITextField(db.frm2.guitarist)
+    >>> adapted.widget="TEXTAREA"
+    >>> print pphtml(db.frm2.displayDocument(None, True, True))
+    <input type="hidden" name="Form" value="frm2" />
+    3
+    <p>
+     Who is the guitarist:
+     <label for="guitarist">
+      Title for guitarist
+     </label>
+    </p>
+    <span>
+     <textarea id="guitarist" name="guitarist">
+     </textarea>
+    </span>
+    <fieldset>
+     <legend class="required">
+      Label for bassist
+     </legend>
+     <span>
+      <input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones" />
+      <label for="bassist-John Paul Jones">
+       John Paul Jones
+      </label>
+      <input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon" />
+      <label for="bassist-Chris Chameleon">
+       Chris Chameleon
+      </label>
+     </span>
+    </fieldset>
+    <fieldset>
+     <legend>
+      Title for drummer
+     </legend>
+     <span>
+      <input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham" />
+      <label for="drummer-John Bonham">
+       John Bonham
+      </label>
+      <input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie" />
+      <label for="drummer-Princess Leonie">
+       Princess Leonie
+      </label>
+     </span>
+    </fieldset>
+
+.. todo:: We need a test for a selection list with no value in edit mode. It should not render a label.

--- a/Products/CMFPlomino/tests/layout.txt
+++ b/Products/CMFPlomino/tests/layout.txt
@@ -110,6 +110,112 @@ if we have some text inbetween just as help text this will be preserved
       </p>
      </div>
 
+It's legal to have two labels for the same field
+
+
+    >>> db.frm1.setFormLayout("""
+    ... <p><span class="plominoLabelClass">field1:my label 1</span></p>
+    ... <p><span class="plominoLabelClass">field1:my label 2</span></p>
+    ... <p><span class="plominoFieldClass">field1</span></p>
+    ... """)
+    >>> print pphtml(db.frm1.displayDocument(None, True, True))
+    <input type="hidden" name="Form" value="frm1" />
+    <div class="plominoFieldGroup required">
+     <p>
+      <label for="field1">
+       my label 1
+      </label>
+     </p>
+     <p>
+      <label for="field1">
+       my label 2
+      </label>
+     </p>
+     <p>
+      <span>
+       <input type="text" id="field1" value="" name="field1" />
+      </span>
+     </p>
+    </div>
+
+#TODO: can you have multiple legends?
+
+The label can be below the field
+
+    >>> db.frm1.setFormLayout("""
+    ... <p><span class="plominoFieldClass">field1</span></p>
+    ... <p><span class="plominoLabelClass">field1:my label 2</span></p>
+    ... """)
+    >>> print pphtml(db.frm1.displayDocument(None, True, True))
+    <input type="hidden" name="Form" value="frm1" />
+    <div class="plominoFieldGroup required">
+     <p>
+      <span>
+       <input type="text" id="field1" value="" name="field1" />
+      </span>
+     </p>
+     <p>
+      <label for="field1">
+       my label 2
+      </label>
+     </p>
+    </div>
+
+
+It will still group with a label on either side
+    >>> db.frm1.setFormLayout("""
+    ... <p><span class="plominoLabelClass">field1:my label 1</span></p>
+    ... <p><span class="plominoFieldClass">field1</span></p>
+    ... <p><span class="plominoLabelClass">field1:my label 2</span></p>
+    ... """)
+    >>> print pphtml(db.frm1.displayDocument(None, True, True))
+    <input type="hidden" name="Form" value="frm1" />
+    <div class="plominoFieldGroup required">
+     <p>
+      <label for="field1">
+       my label 1
+      </label>
+     </p>
+     <p>
+      <span>
+       <input type="text" id="field1" value="" name="field1" />
+      </span>
+     </p>
+     <p>
+      <label for="field1">
+       my label 2
+      </label>
+     </p>
+    </div>
+
+
+We could have two alternative labels using hidewhens.
+
+    >>> id = db.frm1.invokeFactory('PlominoHidewhen', id='is_true',
+    ...         title='is true', formula="True", isDynamicHidewhen=False)
+    >>> db.frm1.field1.at_post_create_script()
+    >>> db.frm1.setFormLayout("""
+    ... <p><span class="plominoLabelClass"><span class="plominoHidewhenClass">start:is_true</span> field1:my label <span class="plominoHidewhenClass">end:is_true</span></span></p>
+    ... <p><span class="plominoLabelClass"><span class="plominoHidewhenClass">start:is_false</span> field1:my label <span class="plominoHidewhenClass">end:is_false</span></span></p>
+    ... <p><span class="plominoFieldClass">field1</span></p>
+    ... """)
+    >>> print pphtml(db.frm1.displayDocument(None, True, True))
+    <input type="hidden" name="Form" value="frm1" />
+    <div class="plominoFieldGroup required">
+     <p>
+      <label for="field1">
+       my label
+      </label>
+     </p>
+     <p>
+       Some help text
+     </p>
+     <p>
+      <span>
+       <input type="text" id="field1" value="" name="field1" />
+      </span>
+     </p>
+    </div>
 
 
 <div>
@@ -120,6 +226,52 @@ if we have some text inbetween just as help text this will be preserved
 </div>
 <p><span><br /></span></p>
 <p>Ê</p>
+
+
+#TODO: test a label for a computed field
+#TODO: test a computed field in the help text
+
+#TODO: test a computed field inside a label
+
+
+If we have a label without a field
+
+     >>> db.frm1.setFormLayout("""
+     ... <p><span class="plominoLabelClass">fieldX:my label</span></p>
+     ... <p>Some help text</p>
+     ... """)
+     >>> print pphtml(db.frm1.displayDocument(None, True, True))
+     <input type="hidden" name="Form" value="frm1" />
+     <p>
+      <span class="plominoLabelClass">
+        fieldX:my label
+      </span>
+     </p>
+     <p>
+      Some help text
+     </p>
+
+and without a field or label text
+
+     >>> db.frm1.setFormLayout("""
+     ... <p><span class="plominoLabelClass">fieldX</span></p>
+     ... <p>Some help text</p>
+     ... """)
+     >>> print pphtml(db.frm1.displayDocument(None, True, True))
+     <input type="hidden" name="Form" value="frm1" />
+     <p>
+      <span class="plominoLabelClass">
+       fieldX
+      </span>
+     </p>
+     <p>
+      Some help text
+     </p>
+
+#TODO: a field without a label and its a checkbox should still be wrapped in a fieldset
+
+#TODO: what if the field exists but isn't in the layout? Should warn the user on save?
+
 
 
 <h2>About what you need</h2>
@@ -265,4 +417,17 @@ HTML 'legend' element.
 .. todo:: test labels below fields
 
 .. todo:: test labels without fieldid
+
+.. todo:: test hidewhens inside a label
+
+.. todo:: fix other tests
+
+.. todo:: test span for label and p for field
+
+.. todo:: test fields in tables and lists
+
+.. todo:: test inline compound field like simple yes no
+
+.. todo:: test boolean field
+
 

--- a/Products/CMFPlomino/tests/layout.txt
+++ b/Products/CMFPlomino/tests/layout.txt
@@ -8,9 +8,11 @@ We need to test code for
  - doing clean up of various non-useful plomino style combinations
 
 
->>> from lxml import etree, html
->>> #pphtml = lambda myhtml: etree.tostring(html.fromstring(myhtml.replace('\t','').replace('\n','')), encoding='unicode', pretty_print=True)
+>>> from lxml import etree, html; from StringIO import StringIO
+>>> parser = etree.HTMLParser(remove_blank_text=True)
+>>> pphtml = lambda myhtml: etree.tostring(html.fromstring(myhtml.replace('\n','')), pretty_print=True)
 >>> from BeautifulSoup import BeautifulSoup; pphtml = lambda myhtml: BeautifulSoup(myhtml).prettify()
+
 
 Let's start testing::
 
@@ -441,7 +443,6 @@ and without a field or label text
 <p><span class="plominoFieldClass">disabilitypaymentpartner</span></p>
 <p><span class="plominoFieldClass"><span class="plominoHidewhenClass"><span class="plominoHidewhenClass">start:disability_payment_partner</span></span></span></p>
 
-https://admin.pretagov.co.uk/05/mnt/www/DWP%20eforms/hardship-payment-1/About_your_health_serious_illness/view
 
 <h2>ÊSerious illness</h2>
 <p><span class="plominoLabelClass">seriousillness:AreÊyou suffering from a serious illness?</span></p>

--- a/Products/CMFPlomino/tests/layout.txt
+++ b/Products/CMFPlomino/tests/layout.txt
@@ -339,7 +339,9 @@ HTML 'legend' element.
 We could have two alternative labels using hidewhens.
 
     >>> id = db.frm1.invokeFactory('PlominoHidewhen', id='is_true',
-    ...         title='is true', formula="True", isDynamicHidewhen=False)
+    ...         title='is true', formula="True", isDynamicHidewhen=True)
+    >>> id = db.frm1.invokeFactory('PlominoHidewhen', id='is_false',
+    ...         title='is false', formula="False", isDynamicHidewhen=True)
     >>> db.frm1.field1.at_post_create_script()
     >>> db.frm1.setFormLayout("""
     ... <p><span class="plominoLabelClass"><span class="plominoHidewhenClass">start:is_true</span> field1:true <span class="plominoHidewhenClass">end:is_true</span></span></p>
@@ -351,16 +353,16 @@ We could have two alternative labels using hidewhens.
     <div class="plominoFieldGroup required">
      <p>
       <label for="field1">
-       <span class="plominoHidewhenClass">start:is_true</span>
+       <div class="hidewhen-is_true">
         true
-       <span class="plominoHidewhenClass">end:is_true</span>
+       </div>
       </label>
      </p>
      <p>
       <label for="field1">
-       <span class="plominoHidewhenClass">start:is_false</span>
+       <div class="hidewhen-is_false">
         false
-       <span class="plominoHidewhenClass">end:is_false</span>
+       </div>
       </label>
      </p>
      <p>
@@ -370,15 +372,6 @@ We could have two alternative labels using hidewhens.
      </p>
     </div>
 
-
-<div>
-<h3><span>About Universal Credit</span></h3>
-<p><span class="plominoLabelClass"><span class="plominoHidewhenClass">start:Not_Single</span> UniversalCreditQuestion: Are you getting Universal Credit or have you applied for it?<span class="plominoHidewhenClass">end:Not_Single</span></span></p>
-<p><span class="plominoLabelClass"><span class="plominoHidewhenClass">start:Not_Partnered</span>UniversalCreditQuestion: Are you or your partner getting Univeral Credit or have either of you applied for it?<span class="plominoHidewhenClass">end:Not_Partnered</span><br /></span></p>
-<p class=" "><span><span class="plominoFieldClass">UniversalCreditQuestion</span></span></p>
-</div>
-<p><span><br /></span></p>
-<p>Ê</p>
 
 
 #TODO: test a label for a computed field

--- a/Products/CMFPlomino/tests/plomino.txt
+++ b/Products/CMFPlomino/tests/plomino.txt
@@ -61,6 +61,8 @@ Let's start testing::
     >>> doc1 = db.createDocument()
     >>> doc2 = db.createDocument()
     >>> doc3 = db.createDocument()
+    >>> from BeautifulSoup import BeautifulSoup; pphtml = lambda myhtml: BeautifulSoup(myhtml).prettify()
+
 
 Forms
 ---------------
@@ -80,8 +82,15 @@ A form can also contain some action buttons to trigger specific processing::
     >>> db.frm1.field1.at_post_create_script()
     >>> db.frm1.setFormLayout("""1 <p>please enter a value for field1:
     ... <span class="plominoFieldClass">field1</span></p>""")
-    >>> db.frm1.displayDocument(None, True, True)
-    u'<input type=\'hidden\' name=\'Form\' value=\'frm1\' />1 <p>please enter a value for field1:<span>\n    \n    \n        <input type="text" id="field1" value="" name="field1" />\n    \n    \n</span>\n</p>'
+    >>> print pphtml(db.frm1.displayDocument(None, True, True))
+    <input type="hidden" name="Form" value="frm1" />
+    1
+    <p>
+     please enter a value for field1:
+     <span>
+      <input type="text" id="field1" value="" name="field1" />
+     </span>
+    </p>
 
 A form can contain editable fields and also computed fields::
 
@@ -231,10 +240,77 @@ A document can be displayed or edited with a form.
 Only items which match a form field will be considered::
 
     >>> doc1.setItem('field1', 'where is my mind?')
-    >>> db.frm1.displayDocument(doc1, editmode=False)
-    u'2 <p>please enter a value for field1:<span class=\'label\' title=\'Label for field1\'>Title for field1</span><span class="TEXTFieldRead-TEXT">\n    \n    \n        where is my mind?\n    \n</span>\n</p><p>Comment:<span class=\'label\' title=\'Label for field2\'>Title for field2</span><span class="TEXTFieldRead-TEXT">\n    \n    \n        My favorite song is where is my mind?\n    \n</span>\n</p><p><span class="TEXTFieldRead-TEXT">\n    \n    \n        WHERE IS MY MIND?\n    \n</span>\n</p><p><span class="TEXTFieldRead-TEXT">\n    \n    \n        side-effect\n    \n</span>\n</p>'
-    >>> db.frm1.displayDocument(doc1, editmode=True)
-    u'<input type=\'hidden\' name=\'Form\' value=\'frm1\' />2 <p>please enter a value for field1:<label for=\'field1\' class=\'required\'>Title for field1</label><span>\n    \n    \n        <input type="text" id="field1" value="where is my mind?" name="field1" />\n    \n    \n</span>\n</p><p>Comment:<label for=\'field2\'>Title for field2</label><span class="TEXTFieldRead-TEXT">\n    \n    \n        My favorite song is where is my mind?\n    \n</span>\n</p><p><span class="TEXTFieldRead-TEXT">\n    \n    \n        WHERE IS MY MIND?\n    \n</span>\n</p><p><span>\n    \n    \n        <input type="text" id="field4" value="side-effect" name="field4" />\n    \n    \n</span>\n</p>'
+    >>> print pphtml(db.frm1.displayDocument(doc1, editmode=False))
+    <p>
+     2
+    </p>
+    <p>
+     please enter a value for field1:
+     <span class="plominoFieldGroup required">
+      <span class="legend">
+       Title for field1
+      </span>
+      <span class="TEXTFieldRead-TEXT">
+       where is my mind?
+      </span>
+     </span>
+    </p>
+    <p>
+     Comment:
+     <span class="plominoFieldGroup">
+      <span class="legend">
+       Title for field2
+      </span>
+      <span class="TEXTFieldRead-TEXT">
+       My favorite song is where is my mind?
+      </span>
+     </span>
+    </p>
+    <p>
+     <span class="TEXTFieldRead-TEXT">
+      WHERE IS MY MIND?
+     </span>
+    </p>
+    <p>
+     <span class="TEXTFieldRead-TEXT">
+      side-effect
+     </span>
+    </p>
+    >>> print pphtml(db.frm1.displayDocument(doc1, editmode=True))
+    <input type="hidden" name="Form" value="frm1" />
+    2
+    <p>
+     please enter a value for field1:
+     <span class="plominoFieldGroup required">
+      <label for="field1">
+       Title for field1
+      </label>
+      <span>
+       <input type="text" id="field1" value="where is my mind?" name="field1" />
+      </span>
+     </span>
+    </p>
+    <p>
+     Comment:
+     <span class="plominoFieldGroup">
+      <label for="field2">
+       Title for field2
+      </label>
+      <span class="TEXTFieldRead-TEXT">
+       My favorite song is where is my mind?
+      </span>
+     </span>
+    </p>
+    <p>
+     <span class="TEXTFieldRead-TEXT">
+      WHERE IS MY MIND?
+     </span>
+    </p>
+    <p>
+     <span>
+      <input type="text" id="field4" value="side-effect" name="field4" />
+     </span>
+    </p>
 
 ``Form`` is a reserved item which allows to indicate the document default
 form::
@@ -255,7 +331,7 @@ By default, during document creation, the title is the form's title::
     >>> doc1.Title()
     'Form 1'
     >>> db.frm1.setDocumentTitle(
-    ... """'A document about ' + plominoDocument.getItem('field1', "nothing")
+    ... """'A document about ' plominoDocument.getItem('field1', "nothing")
     ... """)
     >>> db.frm1.at_post_edit_script()
     >>> doc1.save()
@@ -276,7 +352,7 @@ so if we stop computing it, it falls back to the last stored value::
     >>> doc1.Title()
     u'A document about London calling'
 
-It's possible to specify storing the computed value, but note that 
+It's possible to specify storing the computed value, but note that
 this introduces complications: write on read, and Author rights::
 
     >>> db.frm1.setDynamicDocumentTitle(True)
@@ -297,7 +373,7 @@ The document id formula is evaluated at creation,
 so it only applies to new documents::
 
     >>> db.frm1.setDocumentId(
-    ... """'A document about ' + plominoDocument.getItem('field1', "nothing")
+    ... """'A document about ' plominoDocument.getItem('field1', "nothing")
     ... """)
     >>> db.frm1.at_post_edit_script()
     >>> doc11 = db.createDocument()
@@ -416,11 +492,11 @@ The default text widget is a basic HTML text input::
     >>> adapted = ISelectionField(db.frm2.drummer)
     >>> adapted.widget = "RADIO"
     >>> adapted.selectionlist = [u"John Bonham", u"Princess Leonie"]
-    >>> db.frm2.displayDocument(None, True, True).replace('\n', '').replace('\t', '')
+    >>> print pphtml(db.frm2.displayDocument(None, True, True))
     u'<input type=\'hidden\' name=\'Form\' value=\'frm2\' />3 <p>Who is the guitarist:<label for=\'guitarist\'>Title for guitarist</label></p><span>                <input type="text" id="guitarist" value="" name="guitarist" />        </span></p></p><fieldset><legend class=\'required\'>Label for bassist</legend><span class="bassist-selectionfield"><span><input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones"><label for="bassist-John Paul Jones">John Paul Jones</label></span><span><input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon"><label for="bassist-Chris Chameleon">Chris Chameleon</label></span></span></fieldset></p></p><fieldset><legend>Title for drummer</legend><span class="drummer-selectionfield"><span><input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham"><label for="drummer-John Bonham">John Bonham</label></span><span><input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie"><label for="drummer-Princess Leonie">Princess Leonie</label></span></span></fieldset></p>'
     >>> adapted = ITextField(db.frm2.guitarist)
     >>> adapted.widget="TEXTAREA"
-    >>> db.frm2.displayDocument(None, True, True).replace('\n', '').replace('\t', '')
+    >>> print pphtml(db.frm2.displayDocument(None, True, True))
     u'<input type=\'hidden\' name=\'Form\' value=\'frm2\' />3 <p>Who is the guitarist:<label for=\'guitarist\'>Title for guitarist</label></p><span>                    <textarea id="guitarist" name="guitarist"></textarea>    </span></p></p><fieldset><legend class=\'required\'>Label for bassist</legend><span class="bassist-selectionfield"><span><input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones"><label for="bassist-John Paul Jones">John Paul Jones</label></span><span><input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon"><label for="bassist-Chris Chameleon">Chris Chameleon</label></span></span></fieldset></p></p><fieldset><legend>Title for drummer</legend><span class="drummer-selectionfield"><span><input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham"><label for="drummer-John Bonham">John Bonham</label></span><span><input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie"><label for="drummer-Princess Leonie">Princess Leonie</label></span></span></fieldset></p>'
 
 .. todo:: We need a test for a selection list with no value in edit mode. It should not render a label.

--- a/Products/CMFPlomino/tests/plomino.txt
+++ b/Products/CMFPlomino/tests/plomino.txt
@@ -331,7 +331,7 @@ By default, during document creation, the title is the form's title::
     >>> doc1.Title()
     'Form 1'
     >>> db.frm1.setDocumentTitle(
-    ... """'A document about ' plominoDocument.getItem('field1', "nothing")
+    ... """'A document about ' + plominoDocument.getItem('field1', "nothing")
     ... """)
     >>> db.frm1.at_post_edit_script()
     >>> doc1.save()
@@ -373,7 +373,7 @@ The document id formula is evaluated at creation,
 so it only applies to new documents::
 
     >>> db.frm1.setDocumentId(
-    ... """'A document about ' plominoDocument.getItem('field1', "nothing")
+    ... """'A document about ' + plominoDocument.getItem('field1', "nothing")
     ... """)
     >>> db.frm1.at_post_edit_script()
     >>> doc11 = db.createDocument()
@@ -493,11 +493,113 @@ The default text widget is a basic HTML text input::
     >>> adapted.widget = "RADIO"
     >>> adapted.selectionlist = [u"John Bonham", u"Princess Leonie"]
     >>> print pphtml(db.frm2.displayDocument(None, True, True))
-    u'<input type=\'hidden\' name=\'Form\' value=\'frm2\' />3 <p>Who is the guitarist:<label for=\'guitarist\'>Title for guitarist</label></p><span>                <input type="text" id="guitarist" value="" name="guitarist" />        </span></p></p><fieldset><legend class=\'required\'>Label for bassist</legend><span class="bassist-selectionfield"><span><input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones"><label for="bassist-John Paul Jones">John Paul Jones</label></span><span><input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon"><label for="bassist-Chris Chameleon">Chris Chameleon</label></span></span></fieldset></p></p><fieldset><legend>Title for drummer</legend><span class="drummer-selectionfield"><span><input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham"><label for="drummer-John Bonham">John Bonham</label></span><span><input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie"><label for="drummer-Princess Leonie">Princess Leonie</label></span></span></fieldset></p>'
+    <input type="hidden" name="Form" value="frm2" />
+     3
+     <div class="plominoFieldGroup">
+      <p>
+       Who is the guitarist:
+       <label for="guitarist">
+        Title for guitarist
+       </label>
+      </p>
+      <span>
+       <input type="text" id="guitarist" value="" name="guitarist" />
+      </span>
+     </div>
+     <span class="plominoFieldGroup required">
+      <label for="bassist">
+       Label for bassist
+      </label>
+      <span class="bassist-selectionfield">
+       <span>
+        <input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones" />
+        <label for="bassist-John Paul Jones">
+         John Paul Jones
+        </label>
+       </span>
+       <span>
+        <input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon" />
+        <label for="bassist-Chris Chameleon">
+         Chris Chameleon
+        </label>
+       </span>
+      </span>
+     </span>
+     <span class="plominoFieldGroup">
+      <label for="drummer">
+       Title for drummer
+      </label>
+      <span class="drummer-selectionfield">
+       <span>
+        <input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham" />
+        <label for="drummer-John Bonham">
+         John Bonham
+        </label>
+       </span>
+       <span>
+        <input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie" />
+        <label for="drummer-Princess Leonie">
+         Princess Leonie
+        </label>
+       </span>
+      </span>
+     </span>
+
     >>> adapted = ITextField(db.frm2.guitarist)
     >>> adapted.widget="TEXTAREA"
     >>> print pphtml(db.frm2.displayDocument(None, True, True))
-    u'<input type=\'hidden\' name=\'Form\' value=\'frm2\' />3 <p>Who is the guitarist:<label for=\'guitarist\'>Title for guitarist</label></p><span>                    <textarea id="guitarist" name="guitarist"></textarea>    </span></p></p><fieldset><legend class=\'required\'>Label for bassist</legend><span class="bassist-selectionfield"><span><input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones"><label for="bassist-John Paul Jones">John Paul Jones</label></span><span><input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon"><label for="bassist-Chris Chameleon">Chris Chameleon</label></span></span></fieldset></p></p><fieldset><legend>Title for drummer</legend><span class="drummer-selectionfield"><span><input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham"><label for="drummer-John Bonham">John Bonham</label></span><span><input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie"><label for="drummer-Princess Leonie">Princess Leonie</label></span></span></fieldset></p>'
+    <input type="hidden" name="Form" value="frm2" />
+    3
+    <div class="plominoFieldGroup">
+     <p>
+      Who is the guitarist:
+      <label for="guitarist">
+       Title for guitarist
+      </label>
+     </p>
+     <span>
+      <textarea id="guitarist" name="guitarist">
+      </textarea>
+     </span>
+    </div>
+    <span class="plominoFieldGroup required">
+     <label for="bassist">
+      Label for bassist
+     </label>
+     <span class="bassist-selectionfield">
+      <span>
+       <input type="checkbox" name="bassist" value="John Paul Jones" id="bassist-John Paul Jones" />
+       <label for="bassist-John Paul Jones">
+        John Paul Jones
+       </label>
+      </span>
+      <span>
+       <input type="checkbox" name="bassist" value="Chris Chameleon" id="bassist-Chris Chameleon" />
+       <label for="bassist-Chris Chameleon">
+        Chris Chameleon
+       </label>
+      </span>
+     </span>
+    </span>
+    <span class="plominoFieldGroup">
+     <label for="drummer">
+      Title for drummer
+     </label>
+     <span class="drummer-selectionfield">
+      <span>
+       <input type="radio" name="drummer" value="John Bonham" id="drummer-John Bonham" />
+       <label for="drummer-John Bonham">
+        John Bonham
+       </label>
+      </span>
+      <span>
+       <input type="radio" name="drummer" value="Princess Leonie" id="drummer-Princess Leonie" />
+       <label for="drummer-Princess Leonie">
+        Princess Leonie
+       </label>
+      </span>
+     </span>
+    </span>
 
 .. todo:: We need a test for a selection list with no value in edit mode. It should not render a label.
 
@@ -525,11 +627,11 @@ Selection field::
     >>> db.cleanRequestCache()
     >>> db.frm2.displayDocument(None, True, True
     ...         ).replace('\n', '').replace('\t', '')
-    u'<input type=\'hidden\' name=\'Form\' value=\'frm2\' />4 <p>choose:<span class="artistsfield-selectionfield"><select id="artistsfield" name="artistsfield"><option value="The Beatles">The Beatles</option><option value="The Doors">The Doors</option><option value="The Pixies">The Pixies</option></select></span></p>'
+    u'<input type="hidden" name="Form" value="frm2"/>4 <p>choose:<span class="artistsfield-selectionfield"><select id="artistsfield" name="artistsfield"><option value="The Beatles">The Beatles</option><option value="The Doors">The Doors</option><option value="The Pixies">The Pixies</option></select></span></p>'
     >>> adapted.widget = "CHECKBOX"
     >>> db.frm2.displayDocument(None, True, True
     ...         ).replace('\n', '').replace('\t', '')
-    u'<input type=\'hidden\' name=\'Form\' value=\'frm2\' />4 <p>choose:<span class="artistsfield-selectionfield"><span><input type="checkbox" name="artistsfield" value="The Beatles" id="artistsfield-The Beatles"><label for="artistsfield-The Beatles">The Beatles</label></span><span><input type="checkbox" name="artistsfield" value="The Doors" id="artistsfield-The Doors"><label for="artistsfield-The Doors">The Doors</label></span><span><input type="checkbox" name="artistsfield" value="The Pixies" id="artistsfield-The Pixies"><label for="artistsfield-The Pixies">The Pixies</label></span></span></p>'
+    u'<input type="hidden" name="Form" value="frm2"/>4 <p>choose:<span class="artistsfield-selectionfield"><span><input type="checkbox" name="artistsfield" value="The Beatles" id="artistsfield-The Beatles"><label for="artistsfield-The Beatles">The Beatles</label></span><span><input type="checkbox" name="artistsfield" value="The Doors" id="artistsfield-The Doors"><label for="artistsfield-The Doors">The Doors</label></span><span><input type="checkbox" name="artistsfield" value="The Pixies" id="artistsfield-The Pixies"><label for="artistsfield-The Pixies">The Pixies</label></span></span></p>'
 
 Date/Time field::
 
@@ -550,11 +652,11 @@ Date/Time field::
     >>> doc4.setItem('Form', 'frm2')
     >>> doc4.save()
     >>> db.frm2.displayDocument(doc4)
-    u'5 <p>last album release date:\n2009-01-17\n\n</p>'
+    u'<p>5 </p><p>last album release date:\n2009-01-17\n\n</p>'
     >>> adapted=IDatetimeField(db.frm2.lastalbum)
     >>> adapted.format=u'%d/%m/%Y %H:%M'
     >>> db.frm2.displayDocument(doc4)
-    u'5 <p>last album release date:\n17/01/2009 18:49\n\n</p>'
+    u'<p>5 </p><p>last album release date:\n17/01/2009 18:49\n\n</p>'
     >>> doc4.getRenderedItem('lastalbum')
     u'\n17/01/2009 18:49\n\n'
 
@@ -601,7 +703,7 @@ Rich-text field::
     >>> doc4.save()
     >>> db.cleanRequestCache()
     >>> db.frm2.displayDocument(doc4).replace('\n', '')
-    u"7 <p>My comments: I am not sure it is <b>correct</b><br/>.So please, check <a href='http://www.google.com'>here</a></p>"
+    u"<p>7 </p><p>My comments: I am not sure it is <b>correct</b><br/>.So please, check <a href='http://www.google.com'>here</a></p>"
     >>> REQUEST = {'comments': """I am not sure it is <b>correct</b><br/>.\n
     ... So please, check <a href='http://www.google.com'>here</a>"""}
     >>> db.frm2.validateInputs(REQUEST)
@@ -623,7 +725,7 @@ A name field allow to select a user in the Plone portal members list::
     ... """9 <p>Who: <span class="plominoFieldClass">buyer</span></p>""")
     >>> db.cleanRequestCache()
     >>> db.frm2.displayDocument(None, True, True).replace('\n', '').replace('\t', '')
-    u'<input type=\'hidden\' name=\'Form\' value=\'frm2\' />9 <p>Who: <span><select multiple="true" lines="4" id="buyer" name="buyer"><option value=""></option><option value="test_user_1_">test_user_1_</option></select></span></p>'
+    u'<input type="hidden" name="Form" value="frm2"/>9 <p>Who: <span><select multiple="true" lines="4" id="buyer" name="buyer"><option value=""></option><option value="test_user_1_">test_user_1_</option></select></span></p>'
 
 Doclink field:
 A Doclink field allows to create a reference to another document::
@@ -669,7 +771,7 @@ A field can be computed::
     >>> doc4.save()
     >>> db.cleanRequestCache()
     >>> db.frm2.displayDocument(doc4)
-    u'11 <p>\n    \n    \n        <span class="TEXTFieldRead-TEXT">Welcome test_user_1_</span>\n    \n\n</p>'
+    u'<p>11 </p><p>\n    \n    \n        <span class="TEXTFieldRead-TEXT">Welcome test_user_1_</span>\n    \n\n</p>'
 
 A field can be computed dynamically::
 
@@ -694,7 +796,7 @@ A field can be computed dynamically::
     >>> doc4.save()
     >>> db.cleanRequestCache()
     >>> db.frm2.displayDocument(doc4)
-    u'12 <p>\n    \n    \n        <span class="TEXTFieldRead-TEXT dynamicfield dynamic-dynamic_display">this is dynamic</span>\n    \n\n</p>'
+    u'<p>12 </p><p>\n    \n    \n        <span class="TEXTFieldRead-TEXT dynamicfield dynamic-dynamic_display">this is dynamic</span>\n    \n\n</p>'
 
 
 Events

--- a/Products/CMFPlomino/tests/plomino.txt
+++ b/Products/CMFPlomino/tests/plomino.txt
@@ -507,7 +507,7 @@ Number field::
     >>> REQUEST = {'price': "zero"}
     >>> db.cleanRequestCache()
     >>> db.frm2.validateInputs(REQUEST)
-    ['price must be a float (submitted value was: zero)']
+    [{'field': 'price', 'error': 'price must be a float (submitted value was: zero)'}]
 
 Rich-text field::
 

--- a/Products/CMFPlomino/tests/tests.py
+++ b/Products/CMFPlomino/tests/tests.py
@@ -17,7 +17,7 @@ doctest.set_unittest_reportflags(
 def test_suite():
     suite = doctest.DocFileSuite(
         'plomino.txt', 'plomino_accessControl.txt', 'samples.txt',
-        'plomino_usage.txt', 'form-resources.txt',
+        'plomino_usage.txt', 'form-resources.txt', 'layout.txt',
         'searchableview.txt',
         globs = {
             'TEST_USER_ID': TEST_USER_ID,

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(name='Products.CMFPlomino',
           'zope.globalrequest',  # This one too.
           'plone.resource',
           'pyquery',
+          'BeautifulSoup',
       ],
       extras_require={
           'test': [

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(name='Products.CMFPlomino',
           'zope.app.component',  # Helps Plone 4.0, should not hurt elsewhere.
           'zope.globalrequest',  # This one too.
           'plone.resource',
+          'pyquery',
       ],
       extras_require={
           'test': [

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(name='Products.CMFPlomino',
           'zope.globalrequest',  # This one too.
           'plone.resource',
           'pyquery',
-          'BeautifulSoup',
       ],
       extras_require={
           'test': [
@@ -52,7 +51,9 @@ setup(name='Products.CMFPlomino',
               'Products.PloneTestCase',
               'selenium',
               # to test import/export of extended fields:
-              'archetypes.schemaextender'
+              'archetypes.schemaextender',
+              # For pretty-printing. Would be good if we didn't need this.
+              'BeautifulSoup',
               ],
           },
       entry_points="""


### PR DESCRIPTION
This PR aims to aims to solve a number of issues.
- https://github.com/plomino/Plomino/issues/620
- https://github.com/plomino/Plomino/issues/619

It improves the label handling code by switching to pyquery instead of regex, making it do a broader search that tries to group a label and field into a span or a div or fieldset where possible (based on the type of field or the what the label or field is contained in. The order of the elements will no longer be changed when using labels. Use of computed fields and hidewhens inside labels will be supported.

There is no code to highlight errors using the returned ids but this can be done at a theme level via JS if needed. The JS can use the groups to highlight a the group of label and field.