### PR TITLE
Without nocall, search view gets called in the condition

### DIFF
--- a/Products/CMFPlomino/skins/cmfplomino_templates/OpenForm.pt
+++ b/Products/CMFPlomino/skins/cmfplomino_templates/OpenForm.pt
@@ -214,12 +214,14 @@ jQuery(document).ready( function() {
                         <tal:results
                             define="searchviewname python:here.getSearchView();
                                     searchviewobj python:here.getParentDatabase().getView(searchviewname);
+                                    searchviewfound python: searchviewobj is not None;
                                     ">
                             <tal:block_no_view_found
-                                condition="not:searchviewobj"
-                                define="error python:here.writeMessageOnPage(searchviewname+' view does not exist.', here.REQUEST, error=True);" />
+                                condition="not:searchviewfound">
+                                <span tal:define="error python:here.writeMessageOnPage(searchviewname+' view does not exist.', here.REQUEST, error=True);" />
+                            </tal:block_no_view_found>
 
-                            <tal:block_view_found condition="searchviewobj">
+                            <tal:block_view_found condition="searchviewfound">
                                 <table 
                                     tal:define="results python:options.get('searchresults');
                                                 count python:len(results) if results else 0;


### PR DESCRIPTION
Using a view object in a `tal:condition` (without `nocall:`) results in the view's `__call__` method getting called. This means that on every search form (which uses a search view), the search view is called once, even before you've passed in a list of objects to display using the view.

Also, when an element has multiple statements, tal is executed as described here: 

http://docs.zope.org/zope2/zope2book/AppendixC.html#order-of-operations

This change makes sure that the error message is only displayed if the condition failed.