### PR TITLE
Fix #652 Datagrid has js error when used in PlominoForm

### DIFF
--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -1592,7 +1592,7 @@ class PlominoForm(ATFolder):
         return True
 
     security.declarePublic('tojson')
-    def tojson(self, REQUEST=None, item=None):
+    def tojson(self, REQUEST=None, item=None, rendered=False):
         """ Return field value as JSON.
         If item=None, return all field values.
         (Note: we use 'item' instead of 'field' to match the
@@ -1604,6 +1604,9 @@ class PlominoForm(ATFolder):
                     'content-type',
                     'application/json; charset=utf-8')
             item = REQUEST.get('item', item)
+            rendered_str = REQUEST.get('rendered', None)
+            if rendered_str:
+                rendered = True
             datatables_format_str = REQUEST.get('datatables', None)
             if datatables_format_str:
                 datatables_format = True
@@ -1621,6 +1624,8 @@ class PlominoForm(ATFolder):
             if field:
                 adapt = field.getSettings()
                 result = adapt.getFieldValue(self, request=REQUEST)
+                result = adapt.rows(
+                        result, rendered=rendered)
 
         if datatables_format:
             result = {

--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -1624,8 +1624,9 @@ class PlominoForm(ATFolder):
             if field:
                 adapt = field.getSettings()
                 result = adapt.getFieldValue(self, request=REQUEST)
-                result = adapt.rows(
-                        result, rendered=rendered)
+                if field.getFieldType() == 'DATAGRID':
+                    result = adapt.rows(
+                            result, rendered=rendered)
 
         if datatables_format:
             result = {

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Pass a TemporaryDocument context to hidewhen evaluation [instification]
 - Allow to display request data with alternate forms and read/edit mode [instification]
 - Check for hidden subforms when validating inputs [instification]
+- Adapt to rows for datagrid field in PlominoForm.tojson [instification]
 
 1.19.4 (2015-04-10)
 -------------------


### PR DESCRIPTION
Fix for #652. If the field type is DATAGRID the returned value is adapted to rows. This is the same behavior used in PlominoDocument.