### PR TITLE
Allow dynamic fields inside label/field groupings

### DIFF
--- a/Products/CMFPlomino/PlominoForm.py
+++ b/Products/CMFPlomino/PlominoForm.py
@@ -656,9 +656,15 @@ class PlominoForm(ATFolder):
                         to_find.remove(field)
                     elif field_node and togroup:
                         # found a field in our group thats not ours
-                        # disolve grouping
-                        togroup = found = []
-                        break
+                        # If it's a dynamic field we want this in our groping
+                        group_field_id = field_node.text().strip()
+                        group_field = self.getFormField(group_field_id)
+                        if group_field is not None and group_field.getIsDynamicField():
+                            found_in_sibling = True
+                        # otherwise disolve grouping
+                        else:
+                            togroup = found = []
+                            break
 
                     for label in set(to_find):
                         if sibling in pq(label).parents() or label == sibling:


### PR DESCRIPTION
The existing `_handleLabels` method in `PlominoForm.py` groups labels/fields together - wrapping them in a `plominoFieldGroup` div or a `fieldset`.

Normally labels/fields are grouped when they're like this:

```
<p><span class="plominoLabelClass">field1</span></p>
<p><span class="plominoFieldClass">field1</span></p>
```

But it also works with things like extra text between the label and field:

```
<p><span class="plominoLabelClass">field1</span></p>
<p class="form-hint">This is some helpful information about the field</p>
<p><span class="plominoFieldClass">field1</span></p>
```

Unfortunately it falls down when a dynamic field is included between the main label/fields:

```
<p><span class="plominoLabelClass">field1</span></p>
<p class="form-hint">Current value is: <span class="plominoFieldClass">dynamicTotal</span></p>
<p><span class="plominoFieldClass">field1</span></p>
```

This Pull Request stops the grouping from dissolving if a dynamic field is included between labels/fields that should normally be grouped together. 