### PR TITLE
Add support for dynamic rendering of display fields

### DIFF
--- a/src/Products/CMFPlomino/browser/static/js/dynamic.js
+++ b/src/Products/CMFPlomino/browser/static/js/dynamic.js
@@ -21,11 +21,13 @@ require([
                 data._docid = self.options.docid;
             }
             data._hidewhens = self.getHidewhens();
+            data._fields = self.getDynamicFields();
             data._validation = field.id;
             $.post(self.options.url + '/dynamic_evaluation',
                 data,
                 function(response) {
                     self.applyHidewhens(response.hidewhens);
+                    self.applyDynamicFields(response.fields);
                 },
                 'json');
         },
@@ -45,6 +47,15 @@ require([
             });
             return hidewhens;
         },
+        getDynamicFields: function() {
+            var self = this;
+            var fields = [];
+            self.$el.find('.dynamicfield').each(function(i, el) {
+                fields.push($(el).attr('data-dynamicfield'));
+            });
+            return fields;
+
+        },
         applyHidewhens: function(hidewhens) {
             var self = this;
             for(var i=0; i<hidewhens.length; i++) {
@@ -56,6 +67,16 @@ require([
                 } else {
                     area.show();
                 }
+            }
+        },
+        applyDynamicFields: function(fields) {
+            var self = this;
+            for(var i=0; i<fields.length; i++) {
+                console.log(fields[i]);
+                var fieldid = fields[i][0];
+                var value = fields[i][1];
+                var field = self.$el.find('.dynamicfield[data-dynamicfield="'+fieldid+'"]');
+                field.text(value);
             }
         }
     });

--- a/src/Products/CMFPlomino/contents/field.py
+++ b/src/Products/CMFPlomino/contents/field.py
@@ -96,6 +96,16 @@ class IPlominoField(model.Schema):
         vocabulary=field_modes,
     )
 
+    isDynamicField = schema.Bool(
+        title=_('CMFPlomino_label_isDynamicField',
+            default="Dynamic rendering"),
+        description=_('CMFPlomino_help_isDynamicField',
+            default="The field will be rendered dynamically "
+                    "when the user enters information"),
+        required=False,
+        default=False,
+    )
+
     directives.widget('formula', klass='plomino-formula')
     formula = schema.Text(
         title=_('CMFPlomino_label_FieldFormula', default="Formula"),

--- a/src/Products/CMFPlomino/contents/form.py
+++ b/src/Products/CMFPlomino/contents/form.py
@@ -877,7 +877,7 @@ class PlominoForm(Container):
                 if not form:
                     db.writeMessageOnPage(
                         "Form %s id missing" % formid, REQUEST, False)
-                    fields_results.append(["%s/%s" % (formid, hwid), True])
+                    fields_results.append(["%s/%s" % (formid, fieldid), True])
                     continue
             if formid not in temp:
                 temp[formid] = getTemporaryDocument(
@@ -891,7 +891,7 @@ class PlominoForm(Container):
                 value = form.computeFieldValue(fieldid, temp[formid])
             except PlominoScriptException, e:
                 e.reportError(
-                    '%s field formula failed' % hwid)
+                    '%s field formula failed' % fieldid)
                 # if error, return an empty value
                 value = ''
             fields_results.append(["%s/%s" % (formid, fieldid), value])

--- a/src/Products/CMFPlomino/contents/form.py
+++ b/src/Products/CMFPlomino/contents/form.py
@@ -810,7 +810,7 @@ class PlominoForm(Container):
 
     def dynamic_evaluation(self, REQUEST):
         """ Return a JSON object to dynamically refresh the form
-        (hidewhens, field validation)
+        (hidewhens, field validation, dynamic fields)
         """
         db = self.getParentDatabase()
         docid = REQUEST.get('_docid')
@@ -865,6 +865,38 @@ class PlominoForm(Container):
                 isHidden = True
             hidewhens_results.append(["%s/%s" % (formid, hwid), isHidden])
         results['hidewhens'] = hidewhens_results
+
+        fields = asList(REQUEST.get('_fields[]', []))
+        fields_results = []
+        for token in fields:
+            (formid, fieldid) = token.split('/')
+            if formid == self.id:
+                form = self
+            else:
+                form = db.getForm(formid)
+                if not form:
+                    db.writeMessageOnPage(
+                        "Form %s id missing" % formid, REQUEST, False)
+                    fields_results.append(["%s/%s" % (formid, hwid), True])
+                    continue
+            if formid not in temp:
+                temp[formid] = getTemporaryDocument(
+                    db,
+                    db.getForm(formid),
+                    REQUEST,
+                    doc,
+                    validation_mode=False)
+            try:
+                # We already have the right form for the field
+                value = form.computeFieldValue(fieldid, temp[formid])
+            except PlominoScriptException, e:
+                e.reportError(
+                    '%s field formula failed' % hwid)
+                # if error, return an empty value
+                value = ''
+            fields_results.append(["%s/%s" % (formid, fieldid), value])
+
+        results['fields'] = fields_results
 
         REQUEST.RESPONSE.setHeader(
             'content-type', 'application/json; charset=utf-8')

--- a/src/Products/CMFPlomino/fields/number_read.pt
+++ b/src/Products/CMFPlomino/fields/number_read.pt
@@ -1,3 +1,10 @@
-<tal:block tal:define="v python:options['fieldvalue'];
-    formatted_value python:options['field'].getSettings().format_value(v)"
-    tal:content="formatted_value">number</tal:block>
+<span tal:define="v python:options['fieldvalue'];
+    field python:options['field'];
+    formatted_value python:field.getSettings().format_value(v);
+    dynamic python:getattr(field, 'isDynamicField', False);
+    field_id python:field.id;
+    form_id python:field.aq_parent.id;
+    klass python:dynamic and 'dynamicfield' or '';"
+    tal:content="formatted_value"
+    tal:attributes="class klass;
+                    data-dynamicfield python:dynamic and '%s/%s' % (form_id, field_id) or None;">number</span>

--- a/src/Products/CMFPlomino/fields/text_read.pt
+++ b/src/Products/CMFPlomino/fields/text_read.pt
@@ -2,8 +2,14 @@
         widget python:field.widget;
         preserve_carriage_returns python:field.preserve_carriage_returns;
         fieldvalue python:(preserve_carriage_returns and options['fieldvalue'].replace('\r', '<br/>')) or options['fieldvalue'];
-        size python:field.size"
-    tal:attributes="class string:TEXTFieldRead-${widget}">
+        size python:field.size;
+        dynamic python:getattr(field, 'isDynamicField', False);
+        field_id python:field.id;
+        form_id python:field.aq_parent.id;
+        default_klass string:TEXTFieldRead-${widget};
+        klass python:dynamic and '%s dynamicfield' % default_klass or default_klass;"
+    tal:attributes="class klass;
+                    data-dynamicfield python:dynamic and '%s/%s' % (form_id, field_id) or None;">
     <tal:widget condition="python:widget=='HIDDEN'">
         <input type="hidden" tal:attributes="id field/id; name field/id; value fieldvalue" />
     </tal:widget>


### PR DESCRIPTION
This pull requests provides the 1x functionality that was added here: https://github.com/plomino/Plomino/pull/673

It adds a "Dynamic Rendering" property to fields so that a Display field can be dynamically evaluated and updated when the form changes.

As before, this currently works for computed display fields that are of type Text/Number.