### PR TITLE
Unquote plus signs when reading input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Restore View custom template
+- Unquote plus signs when reading input [instification]
 
 
 2.0b4 (2016-05-27)

--- a/src/Products/CMFPlomino/contents/form.py
+++ b/src/Products/CMFPlomino/contents/form.py
@@ -30,6 +30,7 @@ from ..utils import (
     urlquote,
 )
 from ..document import getTemporaryDocument
+import urllib
 
 logger = logging.getLogger('Plomino')
 security = ClassSecurityInfo()
@@ -1172,6 +1173,7 @@ class PlominoForm(Container):
                     if submittedValue == '':
                         doc.removeItem(fieldName)
                     else:
+                        submittedValue = urllib.unquote_plus(submittedValue)
                         v = f.processInput(
                             submittedValue,
                             doc,


### PR DESCRIPTION
# User Problem
Using `plominoContext.getItem()` on a temporary document, plus signs are not correctly interpreted as spaces.

e.g. if input is `two words` the value will be `two+words`

This does not happen on saved documents but I can't see how it gets correctly unquoted there.

This PR uses `urllib.unquote_plus` on `submittedValue` if the value is not empty.