### PR TITLE
On display event

### DIFF
--- a/src/Products/CMFPlomino/browser/form.py
+++ b/src/Products/CMFPlomino/browser/form.py
@@ -5,6 +5,9 @@ from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import alsoProvides
 
+from ..config import SCRIPT_ID_DELIMITER
+from ..exceptions import PlominoScriptException
+
 
 class FormView(BrowserView):
 
@@ -18,6 +21,21 @@ class FormView(BrowserView):
         self.target = self.context
 
     def openform(self):
+        if (hasattr(self.context, 'onDisplay') and
+                self.context.onDisplay):
+            try:
+                response = self.context.runFormulaScript(
+                    SCRIPT_ID_DELIMITER.join([
+                        'form', self.context.id, 'ondisplay']),
+                    self.context,
+                    self.context.onDisplay)
+            except PlominoScriptException, e:
+                response = None
+                e.reportError('onDisplay formula failed')
+            # If the onDisplay event returned something, return it
+            # We could do extra handling of the response here if needed
+            if response is not None:
+                return response
         return self.template()
 
     def openbareform(self):

--- a/src/Products/CMFPlomino/contents/form.py
+++ b/src/Products/CMFPlomino/contents/form.py
@@ -1510,3 +1510,15 @@ class PlominoForm(Container):
                 'aaData': result}
 
         return json.dumps(result)
+
+    def getTemporaryDocument(self, doc=None, validation_mode=False):
+        """Return a temporary document based on the current request and form"""
+        db = self.getParentDatabase()
+        request = self.REQUEST
+        return getTemporaryDocument(
+            db,
+            self,
+            request,
+            doc=doc,
+            validation_mode=validation_mode
+            ).__of__(db)

--- a/src/Products/CMFPlomino/contents/form.py
+++ b/src/Products/CMFPlomino/contents/form.py
@@ -156,6 +156,7 @@ class IPlominoForm(model.Schema):
         'events',
         label=_(u'Events'),
         fields=(
+            'onDisplay',
             'onCreateDocument',
             'onOpenDocument',
             'beforeSaveDocument',
@@ -164,6 +165,15 @@ class IPlominoForm(model.Schema):
             'onSearch',
             'beforeCreateDocument',
         ),
+    )
+
+    form.widget('onDisplay', klass='plomino-formula')
+    onDisplay = schema.Text(
+        title=_('CMFPlomino_label_onDisplay',
+            default="On display"),
+        description=_('CMFPlomino_help_onDisplay',
+            default="Action to take when the form is displayed"),
+        required=False,
     )
 
     form.widget('onCreateDocument', klass='plomino-formula')

--- a/src/Products/CMFPlomino/document.py
+++ b/src/Products/CMFPlomino/document.py
@@ -988,6 +988,21 @@ class PlominoDocument(CatalogAware, CMFBTreeFolder, Contained):
         # (as BTreeFolder2 1.0 does not define __nonzero__)
         return True
 
+    def getTemporaryDocument(self, doc=None, validation_mode=False):
+        """Return a temporary document based on the current request and form"""
+        db = self.getParentDatabase()
+        request = self.REQUEST
+        form = self.getForm()
+        if doc is None:
+            doc = self
+        return getTemporaryDocument(
+            db,
+            form,
+            request,
+            doc=doc,
+            validation_mode=validation_mode
+            ).__of__(db)
+
 
 InitializeClass(PlominoDocument)
 addPlominoDocument = Factory(PlominoDocument)


### PR DESCRIPTION
This pull request satisfies: https://github.com/plomino/Plomino/issues/770

It adds a new `onDisplay` event which is called before a Form is rendered. If the event returns a value (such as a Zope Response) this is returned to the user. If nothing is returned the template renders as normal.

It also adds a new API for getting a temporary document in a script based on the current request. This can be used in an Event to more easily get values of fields (and to get calculated fields) rather than having to read them from the request.

```
doc = plominoContext.getTemporaryDocument()

first_name = doc.getItem('first_name')
last_name = doc.getItem('last_name')
calculated_field = plominoContext.computeFieldValue('calculated_field', doc)
```