### PR TITLE
Add option to send plain text emails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 - Restore View custom template
 - Unquote plus signs when reading input [instification]
-
+- Add option to send plain text emails [instification]
 
 2.0b4 (2016-05-27)
 ------------------

--- a/src/Products/CMFPlomino/utils.py
+++ b/src/Products/CMFPlomino/utils.py
@@ -244,26 +244,34 @@ def sendMail(
     db,
     recipients,
     title,
-    html_message,
+    message_in,
     sender=None,
     cc=None,
     bcc=None,
-    immediate=False
+    immediate=False,
+    msg_format='html'
 ):
     """Send an email"""
     host = getToolByName(db, 'MailHost')
+    mtype = 'html'
+    if msg_format == 'html':
+        message = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"' \
+            ' "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n'
+        message = message + "<html>"
+        message = message + message_in
+        message = message + "</html>"
+    elif msg_format == 'text':
+        mtype = 'plain'
+        message = message_in
+    else:
+        raise Exception('Invalid message format')
 
-    message = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"' \
-        ' "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n'
-    message = message + "<html>"
-    message = message + html_message
-    message = message + "</html>"
     if not sender:
         sender = db.getCurrentMember().getProperty("email")
 
     mail_message = message_from_string(asUnicode(message).encode('utf-8'))
     mail_message.set_charset('utf-8')
-    mail_message.set_type("text/html")
+    mail_message.set_type("text/%s" % mtype)
     if cc:
         mail_message['CC'] = Header(cc)
     if bcc:
@@ -274,7 +282,7 @@ def sendMail(
             recipients,
             sender,
             asUnicode(title).encode('utf-8'),
-            msg_type='text/html',
+            msg_type='text/%s' % mtype,
             immediate=immediate
         )
     else:
@@ -283,7 +291,7 @@ def sendMail(
             recipients,
             sender,
             subject=title,
-            subtype='html',
+            subtype=mtype,
             charset='utf-8'
         )
 


### PR DESCRIPTION
Adds message type option to sendMail util allowing text/plain messages to be sent.

Defaults to html to ensure existing use is unaffected.