### PR TITLE
bug fixed: if you change the settings of a dropdown or checkbox it in…

### DIFF
--- a/ide/app/editors/tiny-mce/services/update-field.service.ts
+++ b/ide/app/editors/tiny-mce/services/update-field.service.ts
@@ -68,9 +68,9 @@ export class UpdateFieldService {
                               data-mce-resize="false" 
                               data-plominoid="${id}">
           ${contentString}    
-      </${container}><br />`;
+      </${container}>`;
     } else {
-      content = `<span class="${$class}">${id}</span><br />`;
+      content = `<span class="${$class}">${id}</span>`;
     }
 
     return content;

--- a/ide/app/palette-view/fieldsettings/fieldsettings.component.ts
+++ b/ide/app/palette-view/fieldsettings/fieldsettings.component.ts
@@ -91,7 +91,7 @@ export class FieldSettingsComponent implements OnInit {
                     return this.objService.getFieldSettings(newUrl);
                 }
             })
-            .subscribe(responseHtml => {
+            .subscribe((responseHtml: string) => {
                 this.formTemplate = responseHtml;
                 this.formSaving = false;
                 this.changeDetector.markForCheck();


### PR DESCRIPTION
bug fixed: if you change the settings of a dropdown or checkbox it inserts an extra line break within the group.

Plomino/ide/app/palette-view/fieldsettings/fieldsettings.component.ts - just unimportant type fix
Plomino/ide/app/editors/tiny-mce/services/update-field.service.ts - the problem found and fixed