### PR TITLE
Fix ACL undefined setting on new database

### DIFF
--- a/src/Products/CMFPlomino/events.py
+++ b/src/Products/CMFPlomino/events.py
@@ -27,6 +27,9 @@ def afterDatabaseCreated(obj, event):
     for i in ['resources', 'scripts']:
         manage_addCMFBTreeFolder(obj, id=i)
 
+    # Add permission to avoid manual confirmation dialog
+    if not hasattr(obj, 'specific_rights'):
+        obj.specific_rights = {'specific_deletedocument': 'PlominoAuthor'}
     # Due to plone.protect we need to ensure the resource directory is created
     write_on_read = get_resource_directory()
 


### PR DESCRIPTION
After creating a new Plomino Database, when visit Access Control List page, user are redirected to Confirmation Page, in which they have to confirm their wish to visit such pages. The commit adds default Access Control to all Content Type at the point of creation, the omission of Confirmation page help to integrate third-party pluggin to Plone Plomino System.